### PR TITLE
Improve mobile responsiveness across job and package pages

### DIFF
--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -115,8 +115,8 @@ const Jobs = async ({ searchParams }: JobsPagePropsTypes) => {
 	return (
 	<>
 		<HeaderBackground />
-		<section className="mt-16 mb-20 px-4">
-			<div className="container mx-auto flex flex-col lg:flex-row">
+                <section className="mt-16 mb-20 px-4 sm:px-6">
+                        <div className="container mx-auto flex flex-col gap-10 lg:flex-row lg:items-start">
 				<Topbar
 					defaultJobSearchValue={searchParams?.jobTitle}
 					defaultLocation={defaultLocation?.id}
@@ -136,14 +136,14 @@ const Jobs = async ({ searchParams }: JobsPagePropsTypes) => {
 					experienceLevel={experienceLevels}
 					salary={salaryLabels}
 				/>
-				<div className="px-0 md:px-2 mdl:px-6 flex-grow">
-					<div className="flex items-center justify-between mb-6 py-2 h-14">
-						<p className="text-xl text-gray-600">
-							{jobs?.length || "No"} {jobs?.length > 1 ? "jobs" : "job"} found
-						</p>
-					</div>
+                                <div className="px-0 md:px-2 mdl:px-6 flex-grow">
+                                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-6 py-2">
+                                                <p className="text-xl text-gray-600">
+                                                        {jobs?.length || "No"} {jobs?.length > 1 ? "jobs" : "job"} found
+                                                </p>
+                                        </div>
 
-					<div className="space-y-4">
+                                        <div className="space-y-4">
 						<Suspense fallback={<div>Loading...</div>}>
 							{jobs.jobs?.map((result: any) => (
 								<JobItem data={result} key={result._id} />
@@ -151,20 +151,22 @@ const Jobs = async ({ searchParams }: JobsPagePropsTypes) => {
 						</Suspense>
 					</div>
 
-					<div className="relative mt-16 h-[361px] bg-cover bg-center rounded-lg flex flex-col items-center justify-center text-center"
-						style={{ backgroundImage: "url('/images/green-bg-search.svg')" }}
-					>
-						<h5 className="text-4xl font-bold tracking-wider text-light">
-							Join our Job group on Facebook
-						</h5>
-						<a href="https://www.facebook.com/groups/jobsinpragueforeigners---"
-							target="_blank"
-							className="mt-5 px-8 py-4 bg-dark text-light font-bold text-xl rounded-lg hover:opacity-80"
-						>
-							Join Here
-						</a>
-					</div>
-				</div>
+                                        <div
+                                                className="relative mt-16 bg-cover bg-center rounded-lg flex flex-col items-center justify-center text-center px-6 py-12 sm:px-10"
+                                                style={{ backgroundImage: "url('/images/green-bg-search.svg')" }}
+                                        >
+                                                <h5 className="text-2xl sm:text-4xl font-bold tracking-wider text-light">
+                                                        Join our Job group on Facebook
+                                                </h5>
+                                                <a
+                                                        href="https://www.facebook.com/groups/jobsinpragueforeigners---"
+                                                        target="_blank"
+                                                        className="mt-5 px-8 py-3 sm:py-4 bg-dark text-light font-bold text-lg sm:text-xl rounded-lg hover:opacity-80"
+                                                >
+                                                        Join Here
+                                                </a>
+                                        </div>
+                                </div>
 			</div>
 		</section>
 		</>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -100,6 +100,9 @@ const Home = () => {
       </div>
 
       {/* Footer (hidden on small screens) */}
+      <div className="mt-10 mdl:hidden">
+        <Footer />
+      </div>
       <div className="hidden mdl:block z-50">
         <Footer />
       </div>

--- a/lib/components/dropdown/dropdown.module.scss
+++ b/lib/components/dropdown/dropdown.module.scss
@@ -2,8 +2,9 @@
 @import "@/lib/styles/variables.scss";
 
 .dropdown {
-	max-width: 287px;
-	border-radius: 8px;
+        width: 100%;
+        max-width: 100%;
+        border-radius: 8px;
 
 	.header {
 		height: 36px;
@@ -99,18 +100,10 @@
 	}
 }
 
-@media screen and (max-width: 960px) {
-	.dropdown {
-		min-width: 100%;
-		border-radius: 8px;
-}
-}
-
-
-@media screen and (min-width: 1280px) {
-	.dropdown {
-		min-width: 180px;
-	}
+@media screen and (min-width: 1024px) {
+        .dropdown {
+                max-width: 320px;
+        }
 }
 
 

--- a/lib/components/jobItem/jobItem.tsx
+++ b/lib/components/jobItem/jobItem.tsx
@@ -27,21 +27,23 @@ const JobItem = ({ data }: JobItem) => {
 	return (
 		<>
 			{isClient ? (
-					<div key={data?._id} className="flex flex-col gap-6 justify-between bg-light rounded-lg mb-4 shadow-lg p-6 xl:flex-row lg:gap-8">
-						<div className="flex flex-col gap-6">
-							<div className="flex flex-col gap-6">
-								<h4 className="font-bold text-lg text-dark">{data?.jobTitle}</h4>
-								<div className="max-w-[700px]">
+                                        <div key={data?._id} className="flex flex-col gap-6 justify-between bg-light rounded-lg mb-4 shadow-lg p-6 xl:flex-row lg:gap-8">
+                                                <div className="flex flex-col gap-6">
+                                                        <div className="flex flex-col gap-4">
+                                                                <h4 className="font-bold text-lg text-dark leading-snug sm:text-xl">
+                                                                        {data?.jobTitle}
+                                                                </h4>
+                                                                <div className="max-w-[700px] text-sm sm:text-base">
 								{data?.description && isClient && (
-										<p 
-											dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(truncateText(data.description, 200)) }} 
-											className="text-base text-gray-600" 
-										/>
+                                                                                <p
+                                                                                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(truncateText(data.description, 200)) }}
+                                                                                        className="text-sm text-gray-600 sm:text-base"
+                                                                                />
 								)}
 								</div>
 							</div>
-							<div className="flex items-center gap-5">
-								<p className="flex items-center gap-2 text-gray-600 text-base">
+                                                        <div className="flex flex-wrap items-center gap-4">
+                                                                <p className="flex items-center gap-2 text-gray-600 text-sm sm:text-base">
 									<span className="inline-block">
 										<Image src={locationIcon} alt="location" />
 									</span>
@@ -61,25 +63,25 @@ const JobItem = ({ data }: JobItem) => {
 								
 							</div>
 						</div>
-						<div className="flex flex-col justify-between">
-							<div 
-							onClick={() => push(`/jobs/${data?._id}`)}
-							className="flex justify-end gap-4 items-center">
-								<Image src={saveIcon} alt="save" className="cursor-pointer" />
-								<Image src={moreIcon} alt="more" className="cursor-pointer" />
-							</div>
-							<div className="flex flex-col mt-4">
-								<span className="self-end text-sm text-gray-500">{DateConverter({  mongoDate: data?.advertisedDate })}</span>
-								<div className="flex gap-2 mt-4">
-									<Button
-										className="bg-[#c5f06d] text-gray-800  font-bold text-lg hover:bg-[#006c53] hover:text-white px-6 py-2 rounded-2xl flex gap-1 items-center duration-200"
-										icon="/images/icons/list.svg"
-										hoverIcon="/images/icons/list-white.svg"
-									>
-										<a target="_blank" href={data?.jobUrl} className="text-inherit">
-											Apply Now
-										</a>
-									</Button>
+                                                <div className="flex flex-col justify-between gap-4 xl:items-end">
+                                                        <div
+                                                        onClick={() => push(`/jobs/${data?._id}`)}
+                                                        className="flex justify-end gap-4 items-center">
+                                                                <Image src={saveIcon} alt="save" className="cursor-pointer" />
+                                                                <Image src={moreIcon} alt="more" className="cursor-pointer" />
+                                                        </div>
+                                                        <div className="flex flex-col mt-2 xl:items-end">
+                                                                <span className="self-start text-xs text-gray-500 sm:self-end sm:text-sm">{DateConverter({  mongoDate: data?.advertisedDate })}</span>
+                                                                <div className="flex flex-col sm:flex-row gap-2 mt-4 w-full">
+                                                                        <Button
+                                                                                className="bg-[#c5f06d] text-gray-800 font-bold text-base sm:text-lg hover:bg-[#006c53] hover:text-white px-6 py-2 rounded-2xl flex justify-center gap-1 items-center duration-200 w-full sm:w-auto"
+                                                                                icon="/images/icons/list.svg"
+                                                                                hoverIcon="/images/icons/list-white.svg"
+                                                                        >
+                                                                                <a target="_blank" href={data?.jobUrl} className="text-inherit">
+                                                                                        Apply Now
+                                                                                </a>
+                                                                        </Button>
 									{
 										/*
 										<Button

--- a/lib/components/packages/packagesCheckbox.module.scss
+++ b/lib/components/packages/packagesCheckbox.module.scss
@@ -2,25 +2,25 @@
 @import "@/lib/styles/variables.scss";
 
 .packages-checkbox__container {
-	display: flex;
-	align-items: center;
-	margin-bottom: 10px;
-	gap: 200px;
-	border: 1px solid $border-gradient;
-	border-radius: 8px;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        margin-bottom: 16px;
+        gap: 16px 32px;
+        padding: 20px;
+        border: 1px solid $border-gradient;
+        border-radius: 12px;
 
-	.packages-checkbox__checkboxes__checkbox {
-		display: flex;
-		align-items: center;
-		width: 100%;
-		height: 115px;
-		padding: 0 20px;
-		gap: 41px;
+        .packages-checkbox__checkboxes__checkbox {
+                display: flex;
+                align-items: center;
+                gap: 16px;
+                min-height: 60px;
 
-		&__label {
-			font-size: 18px;
-			color: #1d2427;
-		}
+                &__label {
+                        font-size: 18px;
+                        color: #1d2427;
+                }
 
 		.packages-checkbox__image {
 			width: 25px;
@@ -35,27 +35,35 @@
 		}
 	}
 
-	&.checked {
-		background: rgb(73, 135, 255);
-		background: linear-gradient(90deg, rgba(73, 135, 255, 0.12) 14%, rgba(106, 10, 254, 0.12) 92%);
-		border: none;
-	}
+        .packages-checkbox__image-label-wrapper {
+                display: flex;
+                align-items: center;
+        }
 
-	.packages-checkbox__image-label-wrapper {
-		display: flex;
-		align-items: center;
-	}
+        &.checked {
+                background: linear-gradient(90deg, rgba(73, 135, 255, 0.12) 14%, rgba(106, 10, 254, 0.12) 92%);
+                border: none;
+        }
+}
 
-	@media screen and (min-width: 300px) and (max-width: 1400px) {
-		display: inline;
-		.packages-ellipse_img {
-			display: none;
-		}
-		.packages-checkbox__checkboxes__checkbox {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			flex-direction: column;
-		}
-	}
+@media screen and (max-width: 1024px) {
+        .packages-checkbox__container {
+                flex-direction: column;
+                align-items: stretch;
+                gap: 12px;
+
+                .packages-ellipse_img {
+                        display: none;
+                }
+
+                .packages-checkbox__checkboxes__checkbox {
+                        justify-content: flex-start;
+                        padding: 0;
+                        gap: 12px;
+
+                        label {
+                                text-align: left;
+                        }
+                }
+        }
 }

--- a/lib/components/packages/packagesCheckbox.tsx
+++ b/lib/components/packages/packagesCheckbox.tsx
@@ -4,7 +4,6 @@ import styles from "../../components/packages/packagesCheckbox.module.scss";
 import RadioCheckbox from "../radioCheckbox/RadioCheckbox";
 import Image from "next/image";
 import percent_icon from "../../../public/images/icons/discount.svg";
-import value_icon from "../../../public/images/icons/czechkoruna.svg";
 import ellipse from "../../../public/images/icons/Ellipse.svg";
 import { PackageType } from "@/lib/types/componentTypes";
 
@@ -20,53 +19,58 @@ interface PackageCheckboxProps {
 
 const PackagesCheckbox = ({ title, price, points, percent, value, checked, onChange }: PackageCheckboxProps) => {
 	return (
-		<section
-			className={`${styles["packages-checkbox__container"]} ${checked ? styles.checked : ""}`}
-		>
-			<div className={styles["packages-checkbox__checkboxes__checkbox"]}>
-				<div className={styles["packages-checkbox__image-label-wrapper"]}>
-					<RadioCheckbox
-						checked={checked}
-						onChange={(e) => onChange({ title, points, price, percent, value, active: checked })}
-					/>
-					<label>{title}</label>
-				</div>
-			</div>
+                <section
+                        className={`${styles["packages-checkbox__container"]} ${checked ? styles.checked : ""} w-full`}
+                >
+                        <div className={styles["packages-checkbox__checkboxes__checkbox"]}>
+                                <div className={styles["packages-checkbox__image-label-wrapper"]}>
+                                        <RadioCheckbox
+                                                checked={checked}
+                                                onChange={(e) => onChange({ title, points, price, percent, value, active: checked })}
+                                        />
+                                        <label>{title}</label>
+                                </div>
+                        </div>
 
-			<Image
-				className={styles["packages-ellipse_img"]}
-				src={ellipse}
-				alt={ellipse}
-				width={7}
-				height={7}
-			/>
+                        <Image
+                                className={`${styles["packages-ellipse_img"]} hidden lg:block`}
+                                src={ellipse}
+                                alt='separator'
+                                width={7}
+                                height={7}
+                        />
 
-			<div className={styles["packages-checkbox__checkboxes__checkbox"]}>
-				<div className={styles["packages-checkbox__image-label-wrapper"]}>
-					<Image
-						className={styles["packages-checkbox__image"]}
-						src={percent_icon}
-						alt='percent_icon'
+                        <div className={`${styles["packages-checkbox__checkboxes__checkbox"]} w-full lg:w-auto`}>
+                                <div className={styles["packages-checkbox__image-label-wrapper"]}>
+                                        <Image
+                                                className={styles["packages-checkbox__image"]}
+                                                src={percent_icon}
+                                                alt='percent_icon'
 					/>
 					<label>{percent}</label>
 				</div>
 			</div>
 
-			<Image
-				className={styles["packages-ellipse_img"]}
-				src={ellipse}
-				alt={ellipse}
-				width={7}
-				height={7}
-			/>
+                        <Image
+                                className={`${styles["packages-ellipse_img"]} hidden lg:block`}
+                                src={ellipse}
+                                alt='separator'
+                                width={7}
+                                height={7}
+                        />
 
-			<div className={styles["packages-checkbox__checkboxes__checkbox"]}>
-				<div className={styles["packages-checkbox__image-label-wrapper"]}>
-					<label>{value}</label>
-				</div>
-			</div>
-		</section>
-	);
+                        <div className={`${styles["packages-checkbox__checkboxes__checkbox"]} w-full lg:w-auto`}>
+                                <div className={`${styles["packages-checkbox__image-label-wrapper"]} justify-between w-full gap-2 lg:gap-4`}>
+                                        <label className="text-base lg:text-lg">{value}</label>
+                                        <span className="hidden text-sm text-gray-500 lg:inline">{points} points</span>
+                                </div>
+                                <div className="flex items-center justify-between text-sm text-gray-500 lg:hidden w-full mt-1">
+                                        <span>{percent}</span>
+                                        <span>{points} points</span>
+                                </div>
+                        </div>
+                </section>
+        );
 };
 
 export default PackagesCheckbox;

--- a/lib/components/payment/paymentContainer/paymentContainer.module.scss
+++ b/lib/components/payment/paymentContainer/paymentContainer.module.scss
@@ -2,15 +2,18 @@
 @import "@/lib/styles/variables.scss";
 
 .payment-container {
-	display: flex;
-	flex-direction: column;
-	width: 100%;
-	justify-content: left;
-	margin-top: 24px;
-	&__labels {
-		display: flex;
-		flex-direction: column;
-		margin-bottom: 16px;
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        justify-content: flex-start;
+        align-items: stretch;
+        margin-top: 24px;
+        gap: 16px;
+        &__labels {
+                display: flex;
+                flex-direction: column;
+                margin-bottom: 16px;
+                gap: 12px;
 
 		&__label {
 			color: #1d2427;
@@ -35,11 +38,11 @@
 			color: $grey-medium;
 		}
 	}
-	.payment-container__wrapper {
-		display: flex;
-		justify-content: center;
-		width: 100%;
-		gap: 24px;
+        .payment-container__wrapper {
+                display: flex;
+                justify-content: center;
+                width: 100%;
+                gap: 24px;
 		.payment-container-total-price {
 			display: flex;
 			flex-direction: column;
@@ -73,8 +76,26 @@
 	}
 }
 
-@media screen and (max-width: 900px) {
-	.payment-container__wrapper {
-		flex-direction: column;
-	}
+@media screen and (max-width: 768px) {
+        .payment-container {
+                padding: 0;
+
+                .payment-container__labels {
+                        gap: 10px;
+                        &__label {
+                                font-size: 16px;
+                        }
+
+                        &__subLabel {
+                                font-size: 14px;
+                                flex-direction: column;
+                                align-items: flex-start;
+                                gap: 6px;
+                        }
+                }
+        }
+
+        .payment-container__wrapper {
+                flex-direction: column;
+        }
 }

--- a/lib/components/toolBar/topbar.tsx
+++ b/lib/components/toolBar/topbar.tsx
@@ -77,125 +77,144 @@ const Topbar: React.FC<TopbarProps> = ({
 		[searchParams],
 	);
 
-	return (
-		<div>
-			<button 
-			onClick={() => setIsFilterActive(!isFilterActive)}
-			className="bg-light rounded-md shadow-[0_4px_120px_rgba(151,159,183,0.15)] py-1 px-4 mb-2 text-gray-500 lg:hidden flex items-center">
-				Filter
-			{!isFilterActive ? <TiArrowSortedDown className="h-5 w-5"/> : <TiArrowSortedUp className="h-5 w-5"/>}
-			</button>
-					<div
-					style={style}
-					className={`bg-light rounded-lg ${!isFilterActive ? "hidden" : ""} shadow-[0_4px_120px_rgba(151,159,183,0.15)] py-4 px-6 min-w-[300px]`}
-					>
-					<div className="flex items-center justify-between mb-8">
-						<div className="flex items-center justify-between">
-							<CiSearch className="w-5 h-5 text-gray-500"/>
-							<input
-								defaultValue={defaultJobSearchValue || ""}
-								onChange={(e) =>
-									router.push(pathname + "?" + createQueryString("jobTitle", e.target.value))
-								}
-								type="text"
-								className="w-[188px] h-[32px] placeholder-gray-500 placeholder-opacity-60 placeholder-font-semibold placeholder-line-[21px] text-lg"
-								placeholder="Search job name"
-							/>
-						</div>
-						<Link 
-						className="bg-light rounded-md border border-gray-200 py-1 px-4 mb-2 text-gray-500"
-						href={'/jobs'}>
-							Clear 
-						</Link>
-					</div>
-					{/*  @ts-ignore */}
-					<Dropdown
-						key="work-type-dropdown"
-						defaultSelected={defaultJobCategory}
-						queryPushing={(label: string) =>
-							router.push(pathname + "?" + createQueryString("jobCategory", label))
-						}
-						items={jobCategories}
-						headerTitle={"Category"}
-						icon="/images/icons/findJob.svg"
-					/>
-					{/*  @ts-ignore */}
-					<Dropdown
-						key="work-type-dropdown"
-						defaultSelected={defaultWorkType}
-						queryPushing={(label: string) =>
-							router.push(pathname + "?" + createQueryString("workType", label))
-						}
-						items={workType}
-						headerTitle={"Contract Type"}
-						icon="/images/icons/findJob.svg"
-					/>
-					{/*  @ts-ignore */}
-					<Dropdown
-						key="job-time-dropdown"
-						defaultSelected={defaultJobTime}
-						queryPushing={(label: string) =>
-							router.push(pathname + "?" + createQueryString("jobTime", label))
-						}
-						items={jobTime}
-						headerTitle={"Working hours"}
-						icon="/images/icons/findJob.svg"
-					/>
-					{/*  @ts-ignore */}
-					<Dropdown
-						key="location-dropdown"
-						defaultSelected={defaultLocation}
-						queryPushing={(label: string) =>
-							router.push(pathname + "?" + createQueryString("location", label))
-						}
-						items={locations}
-						headerTitle={"Location"}
-						icon="/images/icons/location.svg"
-					/>
-						{/*  @ts-ignore */}
-						<Dropdown
-						key="location-dropdown"
-						defaultSelected={defaultLanguage}
-						queryPushing={(label: string) =>
-							router.push(pathname + "?" + createQueryString("language", label))
-						}
-						items={languages}
-						headerTitle={"Language"}
-						icon="/images/icons/location.svg"
-					/>
-					{/*  @ts-ignore */}
-					<Dropdown
-						key="salary-dropdown"
-						defaultSelected={defaultSalary}
-						queryPushing={(label: string) =>
-							router.push(pathname + "?" + createQueryString("salaryLabel", label))
-						}
-						items={salary}
-						headerTitle={"Salary"}
-						icon="/images/icons/dollar-circle.svg"
-					/>
-					{/*  @ts-ignore */}
-					<Dropdown
-						key="education-dropdown"
-						defaultSelected={defaultEducation}
-						queryPushing={(label: string) =>
-							router.push(pathname + "?" + createQueryString("education", label))
-						}
-						items={educations}
-						headerTitle={"Education"}
-						icon="/images/icons/case.svg"
-					/>
-					{/*  @ts-ignore */}
-					<Dropdown
-						key="experience-dropdown"
-						defaultSelected={defaultExperienceLevel}
-						queryPushing={(label: string) =>
-							router.push(pathname + "?" + createQueryString("experienceLevel", label))
-						}
-						items={experienceLevel}
-						headerTitle={"Experience Level"}
-						icon="/images/icons/case.svg"
-					/>
+        return (
+                <div className="w-full">
+                        <button
+                                onClick={() => setIsFilterActive(!isFilterActive)}
+                                className="bg-light rounded-md shadow-[0_4px_120px_rgba(151,159,183,0.15)] py-1 px-4 mb-3 text-gray-500 lg:hidden flex items-center gap-2"
+                        >
+                                Filter
+                                {!isFilterActive ? <TiArrowSortedDown className="h-5 w-5" /> : <TiArrowSortedUp className="h-5 w-5" />}
+                        </button>
+                        <div
+                                style={style}
+                                className={`bg-light rounded-lg ${!isFilterActive ? "hidden" : ""} shadow-[0_4px_120px_rgba(151,159,183,0.15)] py-4 px-4 sm:px-6 w-full`}
+                        >
+                                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-6">
+                                        <div className="flex w-full items-center gap-3 rounded-md border border-gray-200 px-3 py-2">
+                                                <CiSearch className="w-5 h-5 text-gray-500" />
+                                                <input
+                                                        defaultValue={defaultJobSearchValue || ""}
+                                                        onChange={(e) =>
+                                                                router.push(pathname + "?" + createQueryString("jobTitle", e.target.value))
+                                                        }
+                                                        type="text"
+                                                        className="w-full text-base placeholder-gray-500 placeholder-opacity-60"
+                                                        placeholder="Search job name"
+                                                />
+                                        </div>
+                                        <Link
+                                                className="bg-light rounded-md border border-gray-200 py-2 px-4 text-gray-500 hover:text-gray-700 hover:border-gray-300 duration-200 sm:self-auto self-start"
+                                                href={"/jobs"}
+                                        >
+                                                Clear
+                                        </Link>
+                                </div>
+                                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-1">
+                                        {/*  @ts-ignore */}
+                                        <div className="w-full">
+                                        <Dropdown
+                                                key="job-category-dropdown"
+                                                defaultSelected={defaultJobCategory}
+                                                queryPushing={(label: string) =>
+                                                        router.push(pathname + "?" + createQueryString("jobCategory", label))
+                                                }
+                                                items={jobCategories}
+                                                headerTitle={"Category"}
+                                                icon="/images/icons/findJob.svg"
+                                        />
+                                        </div>
+                                        {/*  @ts-ignore */}
+                                        <div className="w-full">
+                                        <Dropdown
+                                                key="contract-type-dropdown"
+                                                defaultSelected={defaultWorkType}
+                                                queryPushing={(label: string) =>
+                                                        router.push(pathname + "?" + createQueryString("workType", label))
+                                                }
+                                                items={workType}
+                                                headerTitle={"Contract Type"}
+                                                icon="/images/icons/findJob.svg"
+                                        />
+                                        </div>
+                                        {/*  @ts-ignore */}
+                                        <div className="w-full">
+                                        <Dropdown
+                                                key="job-time-dropdown"
+                                                defaultSelected={defaultJobTime}
+                                                queryPushing={(label: string) =>
+                                                        router.push(pathname + "?" + createQueryString("jobTime", label))
+                                                }
+                                                items={jobTime}
+                                                headerTitle={"Working hours"}
+                                                icon="/images/icons/findJob.svg"
+                                        />
+                                        </div>
+                                        {/*  @ts-ignore */}
+                                        <div className="w-full">
+                                        <Dropdown
+                                                key="location-dropdown"
+                                                defaultSelected={defaultLocation}
+                                                queryPushing={(label: string) =>
+                                                        router.push(pathname + "?" + createQueryString("location", label))
+                                                }
+                                                items={locations}
+                                                headerTitle={"Location"}
+                                                icon="/images/icons/location.svg"
+                                        />
+                                        </div>
+                                                {/*  @ts-ignore */}
+                                        <div className="w-full">
+                                                <Dropdown
+                                                key="language-dropdown"
+                                                defaultSelected={defaultLanguage}
+                                                queryPushing={(label: string) =>
+                                                        router.push(pathname + "?" + createQueryString("language", label))
+                                                }
+                                                items={languages}
+                                                headerTitle={"Language"}
+                                                icon="/images/icons/location.svg"
+                                        />
+                                        </div>
+                                        {/*  @ts-ignore */}
+                                        <div className="w-full">
+                                        <Dropdown
+                                                key="salary-dropdown"
+                                                defaultSelected={defaultSalary}
+                                                queryPushing={(label: string) =>
+                                                        router.push(pathname + "?" + createQueryString("salaryLabel", label))
+                                                }
+                                                items={salary}
+                                                headerTitle={"Salary"}
+                                                icon="/images/icons/dollar-circle.svg"
+                                        />
+                                        </div>
+                                        {/*  @ts-ignore */}
+                                        <div className="w-full">
+                                        <Dropdown
+                                                key="education-dropdown"
+                                                defaultSelected={defaultEducation}
+                                                queryPushing={(label: string) =>
+                                                        router.push(pathname + "?" + createQueryString("education", label))
+                                                }
+                                                items={educations}
+                                                headerTitle={"Education"}
+                                                icon="/images/icons/case.svg"
+                                        />
+                                        </div>
+                                        {/*  @ts-ignore */}
+                                        <div className="w-full">
+                                        <Dropdown
+                                                key="experience-dropdown"
+                                                defaultSelected={defaultExperienceLevel}
+                                                queryPushing={(label: string) =>
+                                                        router.push(pathname + "?" + createQueryString("experienceLevel", label))
+                                                }
+                                                items={experienceLevel}
+                                                headerTitle={"Experience Level"}
+                                                icon="/images/icons/case.svg"
+                                        />
+                                        </div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- update the jobs page hero, metrics, and call-to-action blocks so layouts reflow cleanly on narrow screens
- rework the toolbar filters and dropdown styling plus the JobItem card to better support mobile widths
- refresh package selection and checkout styling, including compact footer rendering for handheld devices

## Testing
- npm run lint *(fails: npm/node are not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4eaf3db3c8330b622475f4a8640ab