### PR TITLE
Revamp job filters with responsive card layout

### DIFF
--- a/lib/components/dropdown/dropdown.module.scss
+++ b/lib/components/dropdown/dropdown.module.scss
@@ -4,105 +4,187 @@
 .dropdown {
         width: 100%;
         max-width: 100%;
-        border-radius: 8px;
+        border-radius: 16px;
+        background: $light;
+        border: 1px solid rgba(151, 159, 183, 0.16);
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        box-shadow: 0 8px 30px rgba(151, 159, 183, 0.08);
+        transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
 
-	.header {
-		height: 36px;
-		display: flex;
-		align-items: center;
-		font-size: 16px;
-		font-weight: 400;
-		line-height: 21px;
-		color: $grey-medium;
-		cursor: pointer;
-		justify-content: space-between;
+        &:hover {
+                box-shadow: 0 14px 45px rgba(151, 159, 183, 0.14);
+                transform: translateY(-2px);
+        }
 
+        .header {
+                display: flex;
+                align-items: flex-start;
+                justify-content: space-between;
+                gap: 12px;
+        }
 
-		span {
-			display: flex;
-			gap: 10px;
-			align-items: center;
-		}
-	}
+        .title {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+        }
 
-	.body {
-		padding: 5px;
-		background: $light;
-		display: none;
-		box-shadow: 0 10px 25px rgba(185, 68, 68, 0.1);
-		border-radius: 8px;
-		margin-top: 6px;
-		position: relative;
-		z-index: 2000;
+        .copy {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+        }
 
-		&.open {
-			display: block;
-		}
-	}
+        .label {
+                font-size: 12px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                color: $grey-medium;
+        }
 
-	.item {
-		padding: 10px;
-		font-size: 14px;
-		font-weight: 600;
-		line-height: 21px;
-		color: $grey-medium;
+        .value {
+                font-size: 16px;
+                font-weight: 600;
+                color: $dark;
+                line-height: 1.4;
+        }
 
-		&:not(:last-of-type) {
-			border-bottom: 1px solid $grey-light;
-		}
+        .icon {
+                width: 18px;
+                height: 18px;
+        }
 
-		&:hover {
-			cursor: pointer;
-			color: $grey-dark;
-		}
-	}
+        .actions {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+        }
 
-	.dot {
-		opacity: 0;
-		color: $grey-medium;
-		transition: all 0.2s ease-in-out;
+        .clearButton {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                border: none;
+                background: rgba(0, 156, 119, 0.1);
+                color: $primary-dark;
+                border-radius: 999px;
+                padding: 6px 12px;
+                font-size: 13px;
+                font-weight: 500;
+                cursor: pointer;
+                transition: background 0.2s ease-in-out, color 0.2s ease-in-out;
 
-		&.selected {
-			opacity: 1;
-		}
-	}
+                &:hover {
+                        background: rgba(0, 156, 119, 0.18);
+                        color: $dark;
+                }
+        }
 
-	.icon {
-		font-size: 13px;
-		color: $grey-medium;
-		transform: rotate(0deg);
-		transition: all 0.2s ease-in-out;
+        .clearIcon {
+                font-size: 16px;
+        }
 
-		&.open {
-			transform: rotate(180deg);
-		}
-	}
+        .toggle {
+                display: none;
+                align-items: center;
+                justify-content: center;
+                width: 32px;
+                height: 32px;
+                border-radius: 999px;
+                border: 1px solid $grey-button-border;
+                background: $light;
+                color: $grey-medium;
+                cursor: pointer;
+                transition: border 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.2s ease-in-out;
 
-	&.dropdown-sort {
-		border: 1.5px solid #e6e6e6;
-		width: 133px;
-		height: 41px;
-		margin-left: 8px;
+                &.open {
+                        transform: rotate(180deg);
+                }
 
-		.header {
-			padding-left: 0;
-			justify-content: center;
-			gap: 5px;
-		}
-	}
+                &:hover {
+                        border-color: $primary-color;
+                        color: $primary-dark;
+                }
+        }
+
+        .body {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 10px;
+        }
+
+        .hidden {
+                display: none;
+        }
+
+        .item {
+                border-radius: 999px;
+                padding: 10px 16px;
+                border: 1px solid $grey-button-border;
+                background: $input-bg;
+                color: $grey-medium;
+                font-size: 14px;
+                font-weight: 500;
+                cursor: pointer;
+                transition: background 0.2s ease-in-out, border 0.2s ease-in-out, color 0.2s ease-in-out;
+
+                &:hover {
+                        border-color: $primary-color;
+                        color: $primary-dark;
+                }
+
+                &.selected {
+                        background: $primary-color;
+                        border-color: $primary-color;
+                        color: $light;
+                        box-shadow: 0 8px 16px rgba(0, 156, 119, 0.2);
+                }
+        }
 }
 
-@media screen and (max-width: 1280px) {
-	.dropdown {
-		.header {
-			padding-left: 0;
-		}
-	}
-}
-
-@media screen and (min-width: 1024px) {
+@media screen and (max-width: 1023px) {
         .dropdown {
-                max-width: 320px;
+                padding: 14px;
+
+                .body {
+                        gap: 8px;
+                }
+        }
+}
+
+@media screen and (max-width: 639px) {
+        .dropdown {
+                gap: 12px;
+
+                .header {
+                        align-items: center;
+                }
+
+                .toggle {
+                        display: inline-flex;
+                }
+
+                .body {
+                        width: calc(100% + 28px);
+                        margin: 0 -14px -6px;
+                        padding: 0 14px 6px;
+                        flex-wrap: nowrap;
+                        overflow-x: auto;
+                        gap: 12px;
+                        scroll-snap-type: x proximity;
+
+                        &::-webkit-scrollbar {
+                                display: none;
+                        }
+                }
+
+                .item {
+                        flex: 0 0 auto;
+                        scroll-snap-align: start;
+                }
         }
 }
 

--- a/lib/components/dropdown/dropdown.tsx
+++ b/lib/components/dropdown/dropdown.tsx
@@ -1,72 +1,133 @@
-'use client';
-import React, { useState} from 'react';
-import Image from 'next/image';
-import {DropdownProps} from '@/lib/types/componentTypes';
+"use client";
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { IoIosClose } from 'react-icons/io';
+import { TiArrowSortedDown, TiArrowSortedUp } from 'react-icons/ti';
+
+import { DropdownProps, optionItems } from '@/lib/types/componentTypes';
 
 import styles from './dropdown.module.scss';
-import arrowIcon from '@/public/images/icons/dropdown-arrow.svg';
-import IconButton from "@mui/material/IconButton";
-import {ClickAwayListener} from "@mui/base";
 
+const Dropdown: React.FC<DropdownProps> = ({
+  items,
+  className,
+  icon,
+  headerTitle,
+  defaultSelected,
+  queryPushing,
+}) => {
+  const [selectedItem, setSelectedItem] = useState<number | string | undefined>(defaultSelected);
+  const [isMobile, setIsMobile] = useState(false);
+  const [isBodyVisible, setIsBodyVisible] = useState(true);
 
-import { IoIosClose } from 'react-icons/io';
+  useEffect(() => {
+    setSelectedItem(defaultSelected);
+  }, [defaultSelected]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
 
-const Dropdown: React.FC<DropdownProps> = ({items, className, icon, headerTitle, defaultSelected, queryPushing}) => {
-  const [isOpen, setOpen] = useState(true); //false
-  const [selectedItem, setSelectedItem] = useState(defaultSelected);
-  const toggleDropdown = () => {
-    //setOpen(!isOpen)
+    const detectDevice = () => {
+      setIsMobile(window.innerWidth < 640);
+    };
+
+    detectDevice();
+    window.addEventListener('resize', detectDevice);
+
+    return () => window.removeEventListener('resize', detectDevice);
+  }, []);
+
+  useEffect(() => {
+    if (isMobile) {
+      setIsBodyVisible(false);
+    } else {
+      setIsBodyVisible(true);
+    }
+  }, [isMobile]);
+
+  const selectedLabel = useMemo(() => {
+    const match = items.find((item) => item.id === selectedItem);
+    if (!match) {
+      return 'All';
+    }
+
+    return String(match.label);
+  }, [items, selectedItem]);
+
+  const handleItemClick = (item: optionItems) => {
+    if (selectedItem === item.id) {
+      return;
+    }
+
+    setSelectedItem(item.id);
+    queryPushing && queryPushing(String(item.label));
+
+    if (isMobile) {
+      setIsBodyVisible(false);
+    }
   };
-  const handleItemClick = (e: any,label:string) => {
-    selectedItem !== e.target.id && setSelectedItem(e.target.id);
-    queryPushing && queryPushing(label)
-    toggleDropdown();
-  }
+
+  const handleReset = () => {
+    setSelectedItem(undefined);
+    queryPushing && queryPushing('');
+
+    if (isMobile) {
+      setIsBodyVisible(false);
+    }
+  };
 
   return (
-    <ClickAwayListener onClickAway={()=>setOpen(true)}> 
-    {/*false*/}
-    <div className={`${styles['dropdown']} ${isOpen && styles['open']} ${className ? styles[className] : ''}`}>
-      <div className={styles['header']} onClick={toggleDropdown} >
-                <span className='min-w-max ml-2'>
-                    {icon && <picture>
-                      <img
-                        src={icon}
-                        alt="button"
-                        className={'location h-4 w-4 '}
-                      />
-                    </picture>}
-                  {/*  @ts-ignore */}
-                  {selectedItem ? items && items?.find(item => item.id == selectedItem)?.label : headerTitle}
-                </span>
-        <div className='w-full p-1'>
-          <Image src={arrowIcon} alt="arrow" className={`${styles['icon']} ${isOpen && styles["open"]}`}/>
+    <div className={`${styles.dropdown} ${className ? styles[className] : ''}`}>
+      <div className={styles.header}>
+        <div className={styles.title}>
+          {icon && (
+            <picture>
+              <img src={icon} alt="" className={styles.icon} />
+            </picture>
+          )}
+
+          <div className={styles.copy}>
+            <span className={styles.label}>{headerTitle}</span>
+            <span className={styles.value}>{selectedLabel}</span>
+          </div>
         </div>
-        <IconButton
-          onClick={() => {
-            queryPushing && queryPushing("")
-            setSelectedItem(undefined)
-            setOpen(true);
-          }}
-        >
-           {/*false*/}
-          <IoIosClose />
-        </IconButton>
+
+        <div className={styles.actions}>
+          {selectedItem !== undefined && (
+            <button type="button" className={styles.clearButton} onClick={handleReset}>
+              <IoIosClose className={styles.clearIcon} />
+              <span>Clear</span>
+            </button>
+          )}
+
+          {isMobile && (
+            <button
+              type="button"
+              className={`${styles.toggle} ${isBodyVisible ? styles.open : ''}`}
+              onClick={() => setIsBodyVisible((prev) => !prev)}
+              aria-label={`Toggle ${headerTitle} filter`}
+            >
+              {isBodyVisible ? <TiArrowSortedUp /> : <TiArrowSortedDown />}
+            </button>
+          )}
+        </div>
       </div>
-      <div className={`${styles['body']} ${isOpen && styles['open']}`}>
-        {items.map((item, idx) => (
-          <>
-            {/*  @ts-ignore */}
-            <div key={idx} className={styles["item"]} onClick={e => handleItemClick(e,item.label)} id={item.id}>
-              <span className={`${styles['dot']} ${item.id == selectedItem && styles['selected']}`}>• </span>
-              {item.label}
-            </div>
-          </>
+
+      <div className={`${styles.body} ${!isBodyVisible ? styles.hidden : ''}`}>
+        {items.map((item) => (
+          <button
+            type="button"
+            key={item.id}
+            onClick={() => handleItemClick(item)}
+            className={`${styles.item} ${selectedItem === item.id ? styles.selected : ''}`}
+          >
+            {item.label}
+          </button>
         ))}
       </div>
     </div>
-    </ClickAwayListener>
   );
 };
 

--- a/lib/components/toolBar/topbar.tsx
+++ b/lib/components/toolBar/topbar.tsx
@@ -164,7 +164,9 @@ const Topbar: React.FC<TopbarProps> = ({
                 <div className="w-full">
                         <button
                                 onClick={() => setIsFilterActive((prev) => !prev)}
-                                className="mb-3 flex items-center gap-2 rounded-md bg-light py-1 px-4 text-gray-500 shadow-[0_4px_120px_rgba(151,159,183,0.15)] lg:hidden"
+                                className="mb-4 flex items-center gap-2 self-start rounded-full border border-gray-200 bg-light/90 py-1.5 px-4 text-sm font-medium text-gray-600 shadow-[0_10px_40px_rgba(151,159,183,0.15)] backdrop-blur lg:hidden"
+                                aria-expanded={isFilterActive}
+                                aria-controls="filters-panel"
                         >
                                 Filter
                                 {isFilterActive ? (
@@ -176,30 +178,31 @@ const Topbar: React.FC<TopbarProps> = ({
 
                         <div
                                 style={style}
-                                className={`w-full rounded-lg bg-light py-4 px-4 shadow-[0_4px_120px_rgba(151,159,183,0.15)] sm:px-6 ${
+                                id="filters-panel"
+                                className={`w-full rounded-3xl border border-gray-100 bg-light/80 py-5 px-4 shadow-[0_24px_120px_rgba(151,159,183,0.18)] backdrop-blur-sm sm:px-6 lg:px-10 ${
                                         isFilterActive ? "block" : "hidden"
                                 }`}
                         >
-                                <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                        <div className="flex w-full items-center gap-3 rounded-md border border-gray-200 px-3 py-2">
+                                <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                                        <div className="flex w-full items-center gap-3 rounded-full border border-gray-200 bg-white/70 px-4 py-2 shadow-inner">
                                                 <CiSearch className="h-5 w-5 text-gray-500" />
                                                 <input
                                                         defaultValue={defaultJobSearchValue || ""}
                                                         onChange={(event) => handleQueryPush("jobTitle", event.target.value)}
                                                         type="text"
-                                                        className="w-full text-base placeholder-gray-500 placeholder-opacity-60"
+                                                        className="w-full bg-transparent text-base placeholder-gray-500 placeholder-opacity-60 focus:outline-none"
                                                         placeholder="Search job name"
                                                 />
                                         </div>
                                         <Link
-                                                className="duration-200 self-start rounded-md border border-gray-200 bg-light py-2 px-4 text-gray-500 hover:border-gray-300 hover:text-gray-700 sm:self-auto"
+                                                className="self-start rounded-full border border-gray-200 bg-white/70 px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800 sm:self-auto"
                                                 href="/jobs"
                                         >
                                                 Clear
                                         </Link>
                                 </div>
 
-                                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-1">
+                                <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
                                         {filters.map((filter) => (
                                                 <div key={filter.key} className="w-full">
                                                         <Dropdown


### PR DESCRIPTION
## Summary
- redesign the job filters into always-visible cards with responsive chip selections
- update the toolbar container styling for improved spacing and clarity across breakpoints
- add mobile-specific controls for collapsing filter sections while keeping desktop filters expanded

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f09971c08330806702b47b46c268