### PR TITLE
Simplify filters into collapsible minimal layout

### DIFF
--- a/lib/components/dropdown/dropdown.module.scss
+++ b/lib/components/dropdown/dropdown.module.scss
@@ -3,106 +3,140 @@
 
 .dropdown {
         width: 100%;
-        max-width: 100%;
-        border-radius: 8px;
+        border-radius: 14px;
+        border: 1px solid rgba(151, 159, 183, 0.2);
+        background: $light;
+        padding: 12px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
 
-	.header {
-		height: 36px;
-		display: flex;
-		align-items: center;
-		font-size: 16px;
-		font-weight: 400;
-		line-height: 21px;
-		color: $grey-medium;
-		cursor: pointer;
-		justify-content: space-between;
+        .header {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 12px;
+                border: none;
+                background: transparent;
+                cursor: pointer;
+                padding: 0;
+                text-align: left;
 
+                &:focus-visible {
+                        outline: 2px solid $primary-color;
+                        outline-offset: 3px;
+                }
+        }
 
-		span {
-			display: flex;
-			gap: 10px;
-			align-items: center;
-		}
-	}
+        .title {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+        }
 
-	.body {
-		padding: 5px;
-		background: $light;
-		display: none;
-		box-shadow: 0 10px 25px rgba(185, 68, 68, 0.1);
-		border-radius: 8px;
-		margin-top: 6px;
-		position: relative;
-		z-index: 2000;
+        .copy {
+                display: flex;
+                flex-direction: column;
+                gap: 2px;
+        }
 
-		&.open {
-			display: block;
-		}
-	}
+        .label {
+                font-size: 11px;
+                letter-spacing: 0.1em;
+                text-transform: uppercase;
+                color: $grey-medium;
+        }
 
-	.item {
-		padding: 10px;
-		font-size: 14px;
-		font-weight: 600;
-		line-height: 21px;
-		color: $grey-medium;
+        .value {
+                font-size: 15px;
+                font-weight: 600;
+                color: $dark;
+        }
 
-		&:not(:last-of-type) {
-			border-bottom: 1px solid $grey-light;
-		}
+        .icon {
+                width: 16px;
+                height: 16px;
+        }
 
-		&:hover {
-			cursor: pointer;
-			color: $grey-dark;
-		}
-	}
+        .toggle {
+                font-size: 18px;
+                color: $grey-medium;
+                transition: transform 0.2s ease-in-out;
 
-	.dot {
-		opacity: 0;
-		color: $grey-medium;
-		transition: all 0.2s ease-in-out;
+                &.open {
+                        transform: rotate(180deg);
+                }
+        }
 
-		&.selected {
-			opacity: 1;
-		}
-	}
+        .actions {
+                display: flex;
+                justify-content: flex-end;
+                margin-top: -4px;
+        }
 
-	.icon {
-		font-size: 13px;
-		color: $grey-medium;
-		transform: rotate(0deg);
-		transition: all 0.2s ease-in-out;
+        .clearButton {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                border: none;
+                background: none;
+                color: $primary-dark;
+                font-size: 13px;
+                font-weight: 500;
+                cursor: pointer;
+                padding: 0;
 
-		&.open {
-			transform: rotate(180deg);
-		}
-	}
+                &:hover {
+                        color: $dark;
+                }
+        }
 
-	&.dropdown-sort {
-		border: 1.5px solid #e6e6e6;
-		width: 133px;
-		height: 41px;
-		margin-left: 8px;
+        .clearIcon {
+                font-size: 16px;
+        }
 
-		.header {
-			padding-left: 0;
-			justify-content: center;
-			gap: 5px;
-		}
-	}
+        .body {
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+        }
+
+        .hidden {
+                display: none;
+        }
+
+        .item {
+                border-radius: 10px;
+                padding: 8px 12px;
+                border: 1px solid rgba(151, 159, 183, 0.2);
+                background: rgba(244, 247, 252, 0.6);
+                color: $grey-medium;
+                font-size: 14px;
+                font-weight: 500;
+                cursor: pointer;
+                text-align: left;
+                transition: background 0.2s ease-in-out, border 0.2s ease-in-out, color 0.2s ease-in-out;
+
+                &:hover {
+                        border-color: $primary-color;
+                        color: $primary-dark;
+                }
+
+                &.selected {
+                        background: rgba(0, 156, 119, 0.12);
+                        border-color: $primary-color;
+                        color: $primary-dark;
+                }
+        }
 }
 
-@media screen and (max-width: 1280px) {
-	.dropdown {
-		.header {
-			padding-left: 0;
-		}
-	}
-}
-
-@media screen and (min-width: 1024px) {
+@media screen and (max-width: 639px) {
         .dropdown {
-                max-width: 320px;
+                padding: 12px;
+
+                .value {
+                        font-size: 14px;
+                }
         }
 }
 

--- a/lib/components/toolBar/topbar.tsx
+++ b/lib/components/toolBar/topbar.tsx
@@ -164,7 +164,9 @@ const Topbar: React.FC<TopbarProps> = ({
                 <div className="w-full">
                         <button
                                 onClick={() => setIsFilterActive((prev) => !prev)}
-                                className="mb-3 flex items-center gap-2 rounded-md bg-light py-1 px-4 text-gray-500 shadow-[0_4px_120px_rgba(151,159,183,0.15)] lg:hidden"
+                                className="mb-4 flex items-center gap-2 self-start rounded-full border border-gray-200 bg-light/90 py-1.5 px-4 text-sm font-medium text-gray-600 shadow-[0_10px_40px_rgba(151,159,183,0.15)] backdrop-blur lg:hidden"
+                                aria-expanded={isFilterActive}
+                                aria-controls="filters-panel"
                         >
                                 Filter
                                 {isFilterActive ? (
@@ -176,30 +178,31 @@ const Topbar: React.FC<TopbarProps> = ({
 
                         <div
                                 style={style}
-                                className={`w-full rounded-lg bg-light py-4 px-4 shadow-[0_4px_120px_rgba(151,159,183,0.15)] sm:px-6 ${
+                                id="filters-panel"
+                                className={`mx-auto w-full max-w-5xl rounded-3xl border border-gray-100 bg-white/70 py-5 px-4 shadow-[0_18px_80px_rgba(151,159,183,0.16)] backdrop-blur-sm sm:px-6 lg:px-8 ${
                                         isFilterActive ? "block" : "hidden"
                                 }`}
                         >
-                                <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                        <div className="flex w-full items-center gap-3 rounded-md border border-gray-200 px-3 py-2">
+                                <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                        <div className="flex w-full items-center gap-3 rounded-full border border-gray-200 bg-white px-4 py-2 shadow-sm">
                                                 <CiSearch className="h-5 w-5 text-gray-500" />
                                                 <input
                                                         defaultValue={defaultJobSearchValue || ""}
                                                         onChange={(event) => handleQueryPush("jobTitle", event.target.value)}
                                                         type="text"
-                                                        className="w-full text-base placeholder-gray-500 placeholder-opacity-60"
+                                                        className="w-full bg-transparent text-base placeholder-gray-500 placeholder-opacity-60 focus:outline-none"
                                                         placeholder="Search job name"
                                                 />
                                         </div>
                                         <Link
-                                                className="duration-200 self-start rounded-md border border-gray-200 bg-light py-2 px-4 text-gray-500 hover:border-gray-300 hover:text-gray-700 sm:self-auto"
+                                                className="self-start rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800 sm:self-auto"
                                                 href="/jobs"
                                         >
                                                 Clear
                                         </Link>
                                 </div>
 
-                                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-1">
+                                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
                                         {filters.map((filter) => (
                                                 <div key={filter.key} className="w-full">
                                                         <Dropdown


### PR DESCRIPTION
## Summary
- streamline dropdown filter component into a minimalist collapsible card with clear reset controls
- lighten the dropdown styling for a cleaner presentation with vertical option lists
- tighten the toolbar filter container width and grid spacing for a more compact layout on the page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f09971c08330806702b47b46c268