### PR TITLE
Refine jobs filters layout and interaction

### DIFF
--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -116,11 +116,11 @@ const Jobs = async ({ searchParams }: JobsPagePropsTypes) => {
 	<>
 		<HeaderBackground />
                 <section className="mt-16 mb-20 px-4 sm:px-6">
-                        <div className="container mx-auto flex flex-col gap-10 lg:flex-row lg:items-start">
-				<Topbar
-					defaultJobSearchValue={searchParams?.jobTitle}
-					defaultLocation={defaultLocation?.id}
-					defaultLanguage={defaultLanguage?.id}
+                        <div className="container mx-auto flex flex-col gap-10">
+                                <Topbar
+                                        defaultJobSearchValue={searchParams?.jobTitle}
+                                        defaultLocation={defaultLocation?.id}
+                                        defaultLanguage={defaultLanguage?.id}
 					defaultEducation={defaultEducation?.id}
 					defaultWorkType={defaultWorkType?.id}
 					defaultJobCategory={defaultJobCategory?.id}
@@ -136,7 +136,7 @@ const Jobs = async ({ searchParams }: JobsPagePropsTypes) => {
 					experienceLevel={experienceLevels}
 					salary={salaryLabels}
 				/>
-                                <div className="px-0 md:px-2 mdl:px-6 flex-grow">
+                                <div className="px-0 md:px-2 mdl:px-6">
                                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-6 py-2">
                                                 <p className="text-xl text-gray-600">
                                                         {jobs?.length || "No"} {jobs?.length > 1 ? "jobs" : "job"} found

--- a/lib/components/toolBar/topbar.tsx
+++ b/lib/components/toolBar/topbar.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { CiSearch } from "react-icons/ci";
-import { TiArrowSortedDown, TiArrowSortedUp } from "react-icons/ti";
+import { FiFilter } from "react-icons/fi";
+import { IoClose } from "react-icons/io5";
 
-import Dropdown from "@/lib/components/dropdown/dropdown";
 import { optionItems } from "@/lib/types/componentTypes";
 
 interface TopbarProps {
@@ -51,20 +51,13 @@ const Topbar: React.FC<TopbarProps> = ({
 	defaultJobSearchValue,
 	defaultExperienceLevel,
 }) => {
-        const [isFilterActive, setIsFilterActive] = useState<boolean>(true);
+        const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
+        const [searchValue, setSearchValue] = useState(() =>
+                defaultJobSearchValue ? String(defaultJobSearchValue) : "",
+        );
         const searchParams = useSearchParams();
         const router = useRouter();
         const pathname = usePathname();
-
-        const createQueryString = useCallback(
-                (name: string, value: string) => {
-                        const params = new URLSearchParams(searchParams.toString());
-                        params.set(name, value);
-
-                        return params.toString();
-                },
-                [searchParams],
-        );
 
         const filters = useMemo(
                 () => [
@@ -153,70 +146,190 @@ const Topbar: React.FC<TopbarProps> = ({
                 ],
         );
 
-        const handleQueryPush = useCallback(
-                (name: string, value: string) => {
-                        router.push(`${pathname}?${createQueryString(name, value)}`);
-                },
-                [createQueryString, pathname, router],
-        );
+        const initialFilterState = useMemo(() => {
+                return filters.reduce((acc, filter) => {
+                        const defaultOption = filter.items.find(
+                                (item) => item.id === filter.defaultSelected,
+                        );
+
+                        return {
+                                ...acc,
+                                [filter.queryKey]: defaultOption ? String(defaultOption.label) : "",
+                        };
+                }, {} as Record<string, string>);
+        }, [filters]);
+
+        const emptyFilterState = useMemo(() => {
+                return filters.reduce(
+                        (acc, filter) => ({
+                                ...acc,
+                                [filter.queryKey]: "",
+                        }),
+                        {} as Record<string, string>,
+                );
+        }, [filters]);
+
+        const [filtersState, setFiltersState] = useState<Record<string, string>>(() => ({
+                ...initialFilterState,
+        }));
+
+        useEffect(() => {
+                setFiltersState({ ...initialFilterState });
+        }, [initialFilterState]);
+
+        useEffect(() => {
+                setSearchValue(defaultJobSearchValue ? String(defaultJobSearchValue) : "");
+        }, [defaultJobSearchValue]);
+
+        const handleApplyFilters = useCallback(() => {
+                const params = new URLSearchParams(searchParams.toString());
+
+                if (searchValue) {
+                        params.set("jobTitle", searchValue);
+                } else {
+                        params.delete("jobTitle");
+                }
+
+                filters.forEach((filter) => {
+                        const value = filtersState[filter.queryKey];
+
+                        if (value) {
+                                params.set(filter.queryKey, value);
+                        } else {
+                                params.delete(filter.queryKey);
+                        }
+                });
+
+                router.push(`${pathname}?${params.toString()}`);
+                setIsFilterModalOpen(false);
+        }, [filters, filtersState, pathname, router, searchParams, searchValue]);
+
+        const handleClearAll = useCallback(() => {
+                setSearchValue("");
+                setFiltersState({ ...emptyFilterState });
+                router.push(pathname);
+                setIsFilterModalOpen(false);
+        }, [emptyFilterState, pathname, router]);
+
+        const handleFilterSelection = useCallback((key: string, value: string) => {
+                setFiltersState((prev) => ({
+                        ...prev,
+                        [key]: value,
+                }));
+        }, []);
 
         return (
                 <div className="w-full">
-                        <button
-                                onClick={() => setIsFilterActive((prev) => !prev)}
-                                className="mb-4 flex items-center gap-2 self-start rounded-full border border-gray-200 bg-light/90 py-1.5 px-4 text-sm font-medium text-gray-600 shadow-[0_10px_40px_rgba(151,159,183,0.15)] backdrop-blur lg:hidden"
-                                aria-expanded={isFilterActive}
-                                aria-controls="filters-panel"
-                        >
-                                Filter
-                                {isFilterActive ? (
-                                        <TiArrowSortedUp className="h-5 w-5" />
-                                ) : (
-                                        <TiArrowSortedDown className="h-5 w-5" />
-                                )}
-                        </button>
-
                         <div
                                 style={style}
-                                id="filters-panel"
-                                className={`mx-auto w-full max-w-5xl rounded-3xl border border-gray-100 bg-white/70 py-5 px-4 shadow-[0_18px_80px_rgba(151,159,183,0.16)] backdrop-blur-sm sm:px-6 lg:px-8 ${
-                                        isFilterActive ? "block" : "hidden"
-                                }`}
+                                className="mx-auto w-full max-w-5xl rounded-3xl border border-gray-100 bg-white/70 py-5 px-4 shadow-[0_18px_80px_rgba(151,159,183,0.16)] backdrop-blur-sm sm:px-6 lg:px-8"
                         >
-                                <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                                         <div className="flex w-full items-center gap-3 rounded-full border border-gray-200 bg-white px-4 py-2 shadow-sm">
                                                 <CiSearch className="h-5 w-5 text-gray-500" />
                                                 <input
-                                                        defaultValue={defaultJobSearchValue || ""}
-                                                        onChange={(event) => handleQueryPush("jobTitle", event.target.value)}
+                                                        value={searchValue}
+                                                        onChange={(event) => setSearchValue(event.target.value)}
+                                                        onKeyDown={(event) => {
+                                                                if (event.key === "Enter") {
+                                                                        handleApplyFilters();
+                                                                }
+                                                        }}
                                                         type="text"
                                                         className="w-full bg-transparent text-base placeholder-gray-500 placeholder-opacity-60 focus:outline-none"
                                                         placeholder="Search job name"
                                                 />
                                         </div>
-                                        <Link
-                                                className="self-start rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800 sm:self-auto"
-                                                href="/jobs"
-                                        >
-                                                Clear
-                                        </Link>
-                                </div>
 
-                                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                                        {filters.map((filter) => (
-                                                <div key={filter.key} className="w-full">
-                                                        <Dropdown
-                                                                key={filter.key}
-                                                                defaultSelected={filter.defaultSelected}
-                                                                queryPushing={(label: string) => handleQueryPush(filter.queryKey, label)}
-                                                                items={filter.items}
-                                                                headerTitle={filter.headerTitle}
-                                                                icon={filter.icon}
-                                                        />
-                                                </div>
-                                        ))}
+                                        <div className="flex items-center gap-3">
+                                                <button
+                                                        type="button"
+                                                        onClick={() => setIsFilterModalOpen(true)}
+                                                        className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
+                                                >
+                                                        <FiFilter className="h-5 w-5" />
+                                                        <span className="hidden sm:inline">Filters</span>
+                                                </button>
+                                                <button
+                                                        type="button"
+                                                        onClick={handleApplyFilters}
+                                                        className="rounded-full bg-dark px-5 py-2 text-sm font-semibold text-white transition duration-200 hover:opacity-90"
+                                                >
+                                                        Search
+                                                </button>
+                                                <Link
+                                                        className="rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
+                                                        href="/jobs"
+                                                >
+                                                        Clear
+                                                </Link>
+                                        </div>
                                 </div>
                         </div>
+
+                        {isFilterModalOpen && (
+                                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+                                        <div className="w-full max-w-3xl rounded-3xl bg-white p-6 shadow-2xl">
+                                                <div className="mb-6 flex items-center justify-between">
+                                                        <h3 className="text-lg font-semibold text-gray-800">Filters</h3>
+                                                        <button
+                                                                type="button"
+                                                                onClick={() => setIsFilterModalOpen(false)}
+                                                                className="rounded-full p-2 text-gray-500 transition hover:bg-gray-100 hover:text-gray-700"
+                                                                aria-label="Close filters"
+                                                        >
+                                                                <IoClose className="h-6 w-6" />
+                                                        </button>
+                                                </div>
+
+                                                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                                                        {filters.map((filter) => (
+                                                                <label key={filter.key} className="flex flex-col gap-2 text-sm text-gray-700">
+                                                                        <span className="font-medium text-gray-600">{filter.headerTitle}</span>
+                                                                        <select
+                                                                                value={filtersState[filter.queryKey] || ""}
+                                                                                onChange={(event) =>
+                                                                                        handleFilterSelection(filter.queryKey, event.target.value)
+                                                                                }
+                                                                                className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-dark focus:outline-none focus:ring-2 focus:ring-dark/20"
+                                                                        >
+                                                                                <option value="">All</option>
+                                                                                {filter.items.map((item) => (
+                                                                                        <option key={item.id} value={String(item.label)}>
+                                                                                                {item.label}
+                                                                                        </option>
+                                                                                ))}
+                                                                        </select>
+                                                                </label>
+                                                        ))}
+                                                </div>
+
+                                                <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+                                                        <button
+                                                                type="button"
+                                                                onClick={() => setFiltersState({ ...emptyFilterState })}
+                                                                className="rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
+                                                        >
+                                                                Reset
+                                                        </button>
+                                                        <button
+                                                                type="button"
+                                                                onClick={handleApplyFilters}
+                                                                className="rounded-full bg-dark px-6 py-2 text-sm font-semibold text-white transition duration-200 hover:opacity-90"
+                                                        >
+                                                                Apply filters
+                                                        </button>
+                                                        <button
+                                                                type="button"
+                                                                onClick={handleClearAll}
+                                                                className="rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
+                                                        >
+                                                                Clear all
+                                                        </button>
+                                                </div>
+                                        </div>
+                                </div>
+                        )}
                 </div>
         );
 


### PR DESCRIPTION
## Summary
- move the jobs filter toolbar above the results list instead of the sidebar
- replace inline dropdowns with a modal-based filter workflow that can be opened from a filter icon
- update filter application logic so keyword search and selected filters are applied together with reset and clear actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d523f7dffc8330ad2abea4ae2fe296