### PR TITLE
Enable multi-select filters on jobs page

### DIFF
--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -86,47 +86,83 @@ async function getOptions() {
 	return res.json();
 }
 
+const parseSearchParam = (param?: string | string[]) => {
+        if (!param) {
+                return [] as string[];
+        }
+
+        const rawValues = Array.isArray(param) ? param : param.split(",");
+
+        return rawValues
+                .map((value) => value.trim())
+                .filter((value): value is string => Boolean(value.length));
+};
+
+const getDefaultIds = (items: optionItems[], selectedLabels: string[]) =>
+        items
+                .filter((item) => selectedLabels.includes(String(item.label)))
+                .map((item) => item.id);
+
 const Jobs = async ({ searchParams }: JobsPagePropsTypes) => {
-	const params = new URLSearchParams({
-		jobTitle: searchParams?.jobTitle || "",
-		location: searchParams?.location || "",
-		language: searchParams?.language || "",
-		workType: searchParams?.workType || "",
-		jobCategory: searchParams?.jobCategory || "",
-		education: searchParams?.education || "",
-		jobTime: searchParams?.jobTime || "",
-		salaryLabel: searchParams?.salaryLabel || "",
-		experienceLevel: searchParams?.experienceLevel || "",
-	});
-	const [jobs, options] = await Promise.all([getData(params), getOptions()]);
+        const params = new URLSearchParams();
+
+        const rawJobTitleValue = Array.isArray(searchParams?.jobTitle)
+                ? searchParams?.jobTitle[0]
+                : searchParams?.jobTitle;
+        const jobTitleValue = rawJobTitleValue?.trim();
+
+        if (jobTitleValue) {
+                params.set("jobTitle", jobTitleValue);
+        }
+
+        const locationFilters = parseSearchParam(searchParams?.location);
+        locationFilters.forEach((value) => params.append("location", value));
+
+        const languageFilters = parseSearchParam(searchParams?.language);
+        languageFilters.forEach((value) => params.append("language", value));
+
+        const workTypeFilters = parseSearchParam(searchParams?.workType);
+        workTypeFilters.forEach((value) => params.append("workType", value));
+
+        const jobCategoryFilters = parseSearchParam(searchParams?.jobCategory);
+        jobCategoryFilters.forEach((value) => params.append("jobCategory", value));
+
+        const educationFilters = parseSearchParam(searchParams?.education);
+        educationFilters.forEach((value) => params.append("education", value));
+
+        const jobTimeFilters = parseSearchParam(searchParams?.jobTime);
+        jobTimeFilters.forEach((value) => params.append("jobTime", value));
+
+        const salaryFilters = parseSearchParam(searchParams?.salaryLabel);
+        salaryFilters.forEach((value) => params.append("salaryLabel", value));
+
+        const experienceFilters = parseSearchParam(searchParams?.experienceLevel);
+        experienceFilters.forEach((value) => params.append("experienceLevel", value));
+
+        const [jobs, options] = await Promise.all([getData(params.toString()), getOptions()]);
 	
 
 	const { locations, languages, workTypes, jobTimes, educations, salaryLabels, experienceLevels, jobCategories } = await processOptions(options);
 
-	const defaultLocation = locations.find((item) => item.label === searchParams?.location);
-	const defaultLanguage = languages.find((item) => item.label === searchParams?.language);
-	const defaultWorkType = workTypes.find((item) => item.label === searchParams?.workType);
-	const defaultJobCategory = jobCategories.find((item) => item.label === searchParams?.jobCategory);
-	const defaultSalaryLabel = salaryLabels.find((item) => item.label === searchParams?.salaryLabel);
-	const defaultJobTime = jobTimes.find((item) => item.label === searchParams?.jobTime);
-	const defaultEducation = educations.find((item) => item.label === searchParams?.education);
-	const defaultExperienceLevel = experienceLevels.find((item) => item.label === searchParams?.experienceLevel);
+        const defaultSelections = {
+                location: getDefaultIds(locations, locationFilters),
+                language: getDefaultIds(languages, languageFilters),
+                education: getDefaultIds(educations, educationFilters),
+                workType: getDefaultIds(workTypes, workTypeFilters),
+                jobCategory: getDefaultIds(jobCategories, jobCategoryFilters),
+                experienceLevel: getDefaultIds(experienceLevels, experienceFilters),
+                jobTime: getDefaultIds(jobTimes, jobTimeFilters),
+                salaryLabel: getDefaultIds(salaryLabels, salaryFilters),
+        } satisfies Partial<Record<string, string[]>>;
 
 	return (
 	<>
 		<HeaderBackground />
                 <section className="mt-16 mb-20 px-4 sm:px-6">
-                        <div className="container mx-auto flex flex-col gap-10 lg:flex-row lg:items-start">
-				<Topbar
-					defaultJobSearchValue={searchParams?.jobTitle}
-					defaultLocation={defaultLocation?.id}
-					defaultLanguage={defaultLanguage?.id}
-					defaultEducation={defaultEducation?.id}
-					defaultWorkType={defaultWorkType?.id}
-					defaultJobCategory={defaultJobCategory?.id}
-					defaultExperienceLevel={defaultExperienceLevel?.id}
-					defaultSalary={defaultSalaryLabel?.id}
-					defaultJobTime={defaultJobTime?.id}
+                        <div className="container mx-auto flex flex-col gap-10">
+                                <Topbar
+                                        defaultJobSearchValue={jobTitleValue}
+                                        defaultSelections={defaultSelections}
 					locations={locations}
 					languages={languages}
 					educations={educations}
@@ -136,7 +172,7 @@ const Jobs = async ({ searchParams }: JobsPagePropsTypes) => {
 					experienceLevel={experienceLevels}
 					salary={salaryLabels}
 				/>
-                                <div className="px-0 md:px-2 mdl:px-6 flex-grow">
+                                <div className="px-0 md:px-2 mdl:px-6">
                                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-6 py-2">
                                                 <p className="text-xl text-gray-600">
                                                         {jobs?.length || "No"} {jobs?.length > 1 ? "jobs" : "job"} found

--- a/lib/components/toolBar/topbar.tsx
+++ b/lib/components/toolBar/topbar.tsx
@@ -1,34 +1,40 @@
 "use client";
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { CiSearch } from "react-icons/ci";
-import { TiArrowSortedDown, TiArrowSortedUp } from "react-icons/ti";
+import { FiFilter } from "react-icons/fi";
+import { IoClose } from "react-icons/io5";
 
-import Dropdown from "@/lib/components/dropdown/dropdown";
 import { optionItems } from "@/lib/types/componentTypes";
 
+type FilterDefinition = {
+        key: string;
+        defaultSelectedIds: string[];
+        queryKey: string;
+        items: optionItems[];
+        headerTitle: string;
+        icon: string;
+};
+
+const cloneFilterState = (state: Record<string, string[]>) =>
+        Object.fromEntries(
+                Object.entries(state).map(([key, values]) => [key, [...values]]),
+        ) as Record<string, string[]>;
+
 interface TopbarProps {
-	style?: React.CSSProperties;
-	locations: optionItems[];
-	languages: optionItems[];
-	educations: optionItems[];
-	experienceLevel: optionItems[];
-	workType: optionItems[];
-	jobCategories: optionItems[];
-	jobTime: optionItems[];
-	salary: optionItems[];
-	defaultJobTitle?: string;
-	defaultLocation?: string;
-	defaultLanguage?: string;
-	defaultEducation?: string;
-	defaultExperienceLevel: string | undefined;
-	defaultWorkType?: string;
-	defaultJobCategory?: string;
-	defaultJobTime?: string;
-	defaultSalary?: string;
-	defaultJobSearchValue?: string | number;
+        style?: React.CSSProperties;
+        locations: optionItems[];
+        languages: optionItems[];
+        educations: optionItems[];
+        experienceLevel: optionItems[];
+        workType: optionItems[];
+        jobCategories: optionItems[];
+        jobTime: optionItems[];
+        salary: optionItems[];
+        defaultJobSearchValue?: string | number;
+        defaultSelections?: Partial<Record<string, string[]>>;
 }
 
 const Topbar: React.FC<TopbarProps> = ({
@@ -41,36 +47,22 @@ const Topbar: React.FC<TopbarProps> = ({
 	experienceLevel,
 	jobTime,
 	salary,
-	defaultLocation,
-	defaultLanguage,
-	defaultWorkType,
-	defaultJobCategory,
-	defaultEducation,
-	defaultJobTime,
-	defaultSalary,
-	defaultJobSearchValue,
-	defaultExperienceLevel,
+        defaultJobSearchValue,
+        defaultSelections,
 }) => {
-        const [isFilterActive, setIsFilterActive] = useState<boolean>(true);
+        const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
+        const [searchValue, setSearchValue] = useState(() =>
+                defaultJobSearchValue ? String(defaultJobSearchValue) : "",
+        );
         const searchParams = useSearchParams();
         const router = useRouter();
         const pathname = usePathname();
 
-        const createQueryString = useCallback(
-                (name: string, value: string) => {
-                        const params = new URLSearchParams(searchParams.toString());
-                        params.set(name, value);
-
-                        return params.toString();
-                },
-                [searchParams],
-        );
-
-        const filters = useMemo(
+        const filters = useMemo<FilterDefinition[]>(
                 () => [
                         {
                                 key: "job-category-dropdown",
-                                defaultSelected: defaultJobCategory,
+                                defaultSelectedIds: defaultSelections?.jobCategory ?? [],
                                 queryKey: "jobCategory",
                                 items: jobCategories,
                                 headerTitle: "Category",
@@ -78,7 +70,7 @@ const Topbar: React.FC<TopbarProps> = ({
                         },
                         {
                                 key: "contract-type-dropdown",
-                                defaultSelected: defaultWorkType,
+                                defaultSelectedIds: defaultSelections?.workType ?? [],
                                 queryKey: "workType",
                                 items: workType,
                                 headerTitle: "Contract Type",
@@ -86,7 +78,7 @@ const Topbar: React.FC<TopbarProps> = ({
                         },
                         {
                                 key: "job-time-dropdown",
-                                defaultSelected: defaultJobTime,
+                                defaultSelectedIds: defaultSelections?.jobTime ?? [],
                                 queryKey: "jobTime",
                                 items: jobTime,
                                 headerTitle: "Working hours",
@@ -94,7 +86,7 @@ const Topbar: React.FC<TopbarProps> = ({
                         },
                         {
                                 key: "location-dropdown",
-                                defaultSelected: defaultLocation,
+                                defaultSelectedIds: defaultSelections?.location ?? [],
                                 queryKey: "location",
                                 items: locations,
                                 headerTitle: "Location",
@@ -102,7 +94,7 @@ const Topbar: React.FC<TopbarProps> = ({
                         },
                         {
                                 key: "language-dropdown",
-                                defaultSelected: defaultLanguage,
+                                defaultSelectedIds: defaultSelections?.language ?? [],
                                 queryKey: "language",
                                 items: languages,
                                 headerTitle: "Language",
@@ -110,7 +102,7 @@ const Topbar: React.FC<TopbarProps> = ({
                         },
                         {
                                 key: "salary-dropdown",
-                                defaultSelected: defaultSalary,
+                                defaultSelectedIds: defaultSelections?.salaryLabel ?? [],
                                 queryKey: "salaryLabel",
                                 items: salary,
                                 headerTitle: "Salary",
@@ -118,7 +110,7 @@ const Topbar: React.FC<TopbarProps> = ({
                         },
                         {
                                 key: "education-dropdown",
-                                defaultSelected: defaultEducation,
+                                defaultSelectedIds: defaultSelections?.education ?? [],
                                 queryKey: "education",
                                 items: educations,
                                 headerTitle: "Education",
@@ -126,7 +118,7 @@ const Topbar: React.FC<TopbarProps> = ({
                         },
                         {
                                 key: "experience-dropdown",
-                                defaultSelected: defaultExperienceLevel,
+                                defaultSelectedIds: defaultSelections?.experienceLevel ?? [],
                                 queryKey: "experienceLevel",
                                 items: experienceLevel,
                                 headerTitle: "Experience Level",
@@ -134,14 +126,7 @@ const Topbar: React.FC<TopbarProps> = ({
                         },
                 ],
                 [
-                        defaultEducation,
-                        defaultExperienceLevel,
-                        defaultJobCategory,
-                        defaultJobTime,
-                        defaultLanguage,
-                        defaultLocation,
-                        defaultSalary,
-                        defaultWorkType,
+                        defaultSelections,
                         educations,
                         experienceLevel,
                         jobCategories,
@@ -153,70 +138,240 @@ const Topbar: React.FC<TopbarProps> = ({
                 ],
         );
 
-        const handleQueryPush = useCallback(
-                (name: string, value: string) => {
-                        router.push(`${pathname}?${createQueryString(name, value)}`);
-                },
-                [createQueryString, pathname, router],
+        const initialFilterState = useMemo(() => {
+                return filters.reduce((acc, filter) => {
+                        const defaultOptions = filter.items.filter((item) =>
+                                filter.defaultSelectedIds.includes(item.id),
+                        );
+
+                        return {
+                                ...acc,
+                                [filter.queryKey]: defaultOptions.map((item) =>
+                                        String(item.label),
+                                ),
+                        };
+                }, {} as Record<string, string[]>);
+        }, [filters]);
+
+        const emptyFilterState = useMemo(() => {
+                return filters.reduce(
+                        (acc, filter) => ({
+                                ...acc,
+                                [filter.queryKey]: [],
+                        }),
+                        {} as Record<string, string[]>,
+                );
+        }, [filters]);
+
+        const [filtersState, setFiltersState] = useState<Record<string, string[]>>(() =>
+                cloneFilterState(initialFilterState),
         );
+
+        useEffect(() => {
+                setFiltersState(cloneFilterState(initialFilterState));
+        }, [initialFilterState]);
+
+        useEffect(() => {
+                setSearchValue(defaultJobSearchValue ? String(defaultJobSearchValue) : "");
+        }, [defaultJobSearchValue]);
+
+        const handleApplyFilters = useCallback(() => {
+                const params = new URLSearchParams(searchParams.toString());
+                const trimmedSearchValue = searchValue.trim();
+
+                if (trimmedSearchValue) {
+                        params.set("jobTitle", trimmedSearchValue);
+                } else {
+                        params.delete("jobTitle");
+                }
+
+                filters.forEach((filter) => {
+                        const values = filtersState[filter.queryKey] ?? [];
+
+                        params.delete(filter.queryKey);
+
+                        values.forEach((value) => {
+                                params.append(filter.queryKey, value);
+                        });
+                });
+
+                router.push(`${pathname}?${params.toString()}`);
+                setIsFilterModalOpen(false);
+        }, [filters, filtersState, pathname, router, searchParams, searchValue]);
+
+        const handleClearAll = useCallback(() => {
+                setSearchValue("");
+                setFiltersState(cloneFilterState(emptyFilterState));
+                router.push(pathname);
+                setIsFilterModalOpen(false);
+        }, [emptyFilterState, pathname, router]);
+
+        const handleFilterSelection = useCallback((key: string, value: string) => {
+                setFiltersState((prev) => {
+                        const currentValues = prev[key] ?? [];
+                        const exists = currentValues.includes(value);
+                        const nextValues = exists
+                                ? currentValues.filter((item) => item !== value)
+                                : [...currentValues, value];
+
+                        return {
+                                ...prev,
+                                [key]: nextValues,
+                        };
+                });
+        }, []);
 
         return (
                 <div className="w-full">
-                        <button
-                                onClick={() => setIsFilterActive((prev) => !prev)}
-                                className="mb-4 flex items-center gap-2 self-start rounded-full border border-gray-200 bg-light/90 py-1.5 px-4 text-sm font-medium text-gray-600 shadow-[0_10px_40px_rgba(151,159,183,0.15)] backdrop-blur lg:hidden"
-                                aria-expanded={isFilterActive}
-                                aria-controls="filters-panel"
-                        >
-                                Filter
-                                {isFilterActive ? (
-                                        <TiArrowSortedUp className="h-5 w-5" />
-                                ) : (
-                                        <TiArrowSortedDown className="h-5 w-5" />
-                                )}
-                        </button>
-
                         <div
                                 style={style}
-                                id="filters-panel"
-                                className={`mx-auto w-full max-w-5xl rounded-3xl border border-gray-100 bg-white/70 py-5 px-4 shadow-[0_18px_80px_rgba(151,159,183,0.16)] backdrop-blur-sm sm:px-6 lg:px-8 ${
-                                        isFilterActive ? "block" : "hidden"
-                                }`}
+                                className="mx-auto w-full max-w-5xl rounded-3xl border border-gray-100 bg-white/70 py-5 px-4 shadow-[0_18px_80px_rgba(151,159,183,0.16)] backdrop-blur-sm sm:px-6 lg:px-8"
                         >
-                                <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                                         <div className="flex w-full items-center gap-3 rounded-full border border-gray-200 bg-white px-4 py-2 shadow-sm">
                                                 <CiSearch className="h-5 w-5 text-gray-500" />
                                                 <input
-                                                        defaultValue={defaultJobSearchValue || ""}
-                                                        onChange={(event) => handleQueryPush("jobTitle", event.target.value)}
+                                                        value={searchValue}
+                                                        onChange={(event) => setSearchValue(event.target.value)}
+                                                        onKeyDown={(event) => {
+                                                                if (event.key === "Enter") {
+                                                                        handleApplyFilters();
+                                                                }
+                                                        }}
                                                         type="text"
                                                         className="w-full bg-transparent text-base placeholder-gray-500 placeholder-opacity-60 focus:outline-none"
                                                         placeholder="Search job name"
                                                 />
                                         </div>
-                                        <Link
-                                                className="self-start rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800 sm:self-auto"
-                                                href="/jobs"
-                                        >
-                                                Clear
-                                        </Link>
-                                </div>
 
-                                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                                        {filters.map((filter) => (
-                                                <div key={filter.key} className="w-full">
-                                                        <Dropdown
-                                                                key={filter.key}
-                                                                defaultSelected={filter.defaultSelected}
-                                                                queryPushing={(label: string) => handleQueryPush(filter.queryKey, label)}
-                                                                items={filter.items}
-                                                                headerTitle={filter.headerTitle}
-                                                                icon={filter.icon}
-                                                        />
-                                                </div>
-                                        ))}
+                                        <div className="flex items-center gap-3">
+                                                <button
+                                                        type="button"
+                                                        onClick={() => setIsFilterModalOpen(true)}
+                                                        className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
+                                                >
+                                                        <FiFilter className="h-5 w-5" />
+                                                        <span className="hidden sm:inline">Filters</span>
+                                                </button>
+                                                <button
+                                                        type="button"
+                                                        onClick={handleApplyFilters}
+                                                        className="rounded-full bg-dark px-5 py-2 text-sm font-semibold text-white transition duration-200 hover:opacity-90"
+                                                >
+                                                        Search
+                                                </button>
+                                                <Link
+                                                        className="rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
+                                                        href="/jobs"
+                                                >
+                                                        Clear
+                                                </Link>
+                                        </div>
                                 </div>
                         </div>
+
+                        {isFilterModalOpen && (
+                                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+                                        <div className="w-full max-w-3xl rounded-3xl bg-white p-6 shadow-2xl">
+                                                <div className="mb-6 flex items-center justify-between">
+                                                        <h3 className="text-lg font-semibold text-gray-800">Filters</h3>
+                                                        <button
+                                                                type="button"
+                                                                onClick={() => setIsFilterModalOpen(false)}
+                                                                className="rounded-full p-2 text-gray-500 transition hover:bg-gray-100 hover:text-gray-700"
+                                                                aria-label="Close filters"
+                                                        >
+                                                                <IoClose className="h-6 w-6" />
+                                                        </button>
+                                                </div>
+
+                                                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                                                        {filters.map((filter) => (
+                                                                <div
+                                                                        key={filter.key}
+                                                                        className="flex flex-col gap-3 rounded-2xl border border-gray-200 p-4 shadow-sm"
+                                                                >
+                                                                        <div className="flex items-center justify-between gap-3">
+                                                                                <span className="text-sm font-semibold text-gray-700">
+                                                                                        {filter.headerTitle}
+                                                                                </span>
+                                                                                <button
+                                                                                        type="button"
+                                                                                        onClick={() =>
+                                                                                                setFiltersState((prev) => ({
+                                                                                                        ...prev,
+                                                                                                        [filter.queryKey]: [],
+                                                                                                }))
+                                                                                        }
+                                                                                        className="text-xs font-medium text-gray-500 transition hover:text-gray-700"
+                                                                                >
+                                                                                        Clear
+                                                                                </button>
+                                                                        </div>
+
+                                                                        <div className="flex max-h-48 flex-col gap-2 overflow-y-auto pr-1 text-sm text-gray-600">
+                                                                                {filter.items.map((item) => {
+                                                                                        const label = String(item.label);
+                                                                                        const checked = (filtersState[filter.queryKey] ?? []).includes(
+                                                                                                label,
+                                                                                        );
+
+                                                                                        return (
+                                                                                                <label
+                                                                                                        key={item.id}
+                                                                                                        className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-gray-100"
+                                                                                                >
+                                                                                                        <input
+                                                                                                                type="checkbox"
+                                                                                                                checked={checked}
+                                                                                                                onChange={() =>
+                                                                                                                        handleFilterSelection(
+                                                                                                                                filter.queryKey,
+                                                                                                                                label,
+                                                                                                                        )
+                                                                                                                }
+                                                                                                                className="h-4 w-4 rounded border-gray-300 text-dark focus:ring-dark/40"
+                                                                                                        />
+                                                                                                        <span className="truncate text-sm text-gray-700">
+                                                                                                                {item.label}
+                                                                                                        </span>
+                                                                                                </label>
+                                                                                        );
+                                                                                })}
+                                                                                {!filter.items.length && (
+                                                                                        <p className="text-xs text-gray-400">No options available</p>
+                                                                                )}
+                                                                        </div>
+                                                                </div>
+                                                        ))}
+                                                </div>
+
+                                                <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+                                                        <button
+                                                                type="button"
+                                                                onClick={() => setFiltersState(cloneFilterState(initialFilterState))}
+                                                                className="rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
+                                                        >
+                                                                Reset
+                                                        </button>
+                                                        <button
+                                                                type="button"
+                                                                onClick={handleApplyFilters}
+                                                                className="rounded-full bg-dark px-6 py-2 text-sm font-semibold text-white transition duration-200 hover:opacity-90"
+                                                        >
+                                                                Apply filters
+                                                        </button>
+                                                        <button
+                                                                type="button"
+                                                                onClick={handleClearAll}
+                                                                className="rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
+                                                        >
+                                                                Clear all
+                                                        </button>
+                                                </div>
+                                        </div>
+                                </div>
+                        )}
                 </div>
         );
 

--- a/lib/types/componentTypes.ts
+++ b/lib/types/componentTypes.ts
@@ -92,19 +92,19 @@ export type ServicePlanType = {
 	price?: number | string;
 };
 export interface JobsPagePropsTypes {
-	params?: { value: string | number };
-	searchParams?: {
-		jobTitle: string | undefined;
-		workType: string | undefined;
-		jobTime: string | undefined;
-		jobCategory: string | undefined;
-		language: string | undefined;
-		location: string | undefined;
-		education: string | undefined;
-		experienceLevel: string | undefined;
-		salary: string | undefined;
-		salaryLabel: string | undefined;
-	};
+        params?: { value: string | number };
+        searchParams?: {
+                jobTitle: string | string[] | undefined;
+                workType: string | string[] | undefined;
+                jobTime: string | string[] | undefined;
+                jobCategory: string | string[] | undefined;
+                language: string | string[] | undefined;
+                location: string | string[] | undefined;
+                education: string | string[] | undefined;
+                experienceLevel: string | string[] | undefined;
+                salary: string | string[] | undefined;
+                salaryLabel: string | string[] | undefined;
+        };
 }
 export type PackageType = {
 	title: string;


### PR DESCRIPTION
## Summary
- update the jobs page to parse multi-value search parameters and pass default selections into the toolbar
- rework the jobs filter modal into multi-select checkboxes with persistent state, reset, and clear handling
- adjust the jobs API filter construction to handle repeated query parameters via regex arrays

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d523f7dffc8330ad2abea4ae2fe296