### PR TITLE
Add backend URL fallbacks to prevent runtime error

### DIFF
--- a/lib/constant/constants.ts
+++ b/lib/constant/constants.ts
@@ -559,15 +559,28 @@ export const COMPANY_SIZE = [
 	"less than 500 Employees"
 ];
 
-const rawBackendUrl = process.env.BACKEND_URL ?? process.env.NEXT_PUBLIC_BACKEND_URL;
+const stripTrailingSlash = (url: string) => url.replace(/\/$/, "");
 
-if (!rawBackendUrl) {
-        throw new Error(
-                "Missing BACKEND_URL environment variable. Set BACKEND_URL (preferred) or NEXT_PUBLIC_BACKEND_URL to the fully qualified API base URL.",
-        );
-}
+const fallbackFrontendUrl = (() => {
+        if (process.env.NEXT_PUBLIC_SITE_URL) {
+                return stripTrailingSlash(process.env.NEXT_PUBLIC_SITE_URL);
+        }
 
-export const BACKEND_URL = rawBackendUrl.replace(/\/$/, "");
+        if (process.env.NEXTAUTH_URL) {
+                return stripTrailingSlash(process.env.NEXTAUTH_URL);
+        }
+
+        if (process.env.VERCEL_URL) {
+                return stripTrailingSlash(`https://${process.env.VERCEL_URL}`);
+        }
+
+        return "http://localhost:3000";
+})();
+
+const rawBackendUrl =
+        process.env.BACKEND_URL ?? process.env.NEXT_PUBLIC_BACKEND_URL ?? `${fallbackFrontendUrl}/api`;
+
+export const BACKEND_URL = stripTrailingSlash(rawBackendUrl);
 
 // REGEXPS
 export const emailValidationRegexp = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;


### PR DESCRIPTION
## Summary
- derive the backend URL from several deployment-related environment variables before falling back to the local dev API
- strip trailing slashes so composed URLs remain well-formed
- prevent the app from throwing when BACKEND_URL variables are missing during development

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d53070acb48330bfaec2434b6470f1