### PR TITLE
Improve desktop filter modal UX

### DIFF
--- a/lib/components/toolBar/topbar.tsx
+++ b/lib/components/toolBar/topbar.tsx
@@ -188,6 +188,23 @@ const Topbar: React.FC<TopbarProps> = ({
                 };
         }, []);
 
+        useEffect(() => {
+                if (typeof document === "undefined" || isMobileView) {
+                        return;
+                }
+
+                const { body } = document;
+                const previousOverflow = body.style.overflow;
+
+                if (isFilterModalOpen) {
+                        body.style.overflow = "hidden";
+                }
+
+                return () => {
+                        body.style.overflow = previousOverflow;
+                };
+        }, [isFilterModalOpen, isMobileView]);
+
         const handleApplyFilters = useCallback(() => {
                 const params = new URLSearchParams(searchParams.toString());
                 const trimmedSearchValue = searchValue.trim();
@@ -267,98 +284,117 @@ const Topbar: React.FC<TopbarProps> = ({
                 }
 
                 return (
-                        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
-                                <div className="w-full max-w-3xl rounded-3xl bg-white p-6 shadow-2xl">
-                                        <div className="mb-6 flex items-center justify-between">
-                                                <h3 className="text-lg font-semibold text-gray-800">Filters</h3>
+                        <div
+                                aria-modal="true"
+                                role="dialog"
+                                className="fixed inset-0 z-[9999] flex items-center justify-center bg-gray-900/60 px-4 py-6 backdrop-blur-sm"
+                                onClick={() => setIsFilterModalOpen(false)}
+                        >
+                                <div
+                                        className="relative flex w-full max-w-5xl max-h-[90vh] flex-col overflow-hidden rounded-3xl bg-white shadow-2xl ring-1 ring-black/5"
+                                        onClick={(event) => event.stopPropagation()}
+                                >
+                                        <div className="flex flex-col gap-3 border-b border-gray-100 px-6 py-5 sm:flex-row sm:items-start sm:justify-between">
+                                                <div className="space-y-1">
+                                                        <h3 className="text-2xl font-semibold text-gray-900">Refine your search</h3>
+                                                        <p className="text-sm text-gray-500">
+                                                                Select the categories that matter most to you to personalise the job results.
+                                                        </p>
+                                                </div>
                                                 <button
                                                         type="button"
                                                         onClick={() => setIsFilterModalOpen(false)}
-                                                        className="rounded-full p-2 text-gray-500 transition hover:bg-gray-100 hover:text-gray-700"
+                                                        className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 text-gray-500 transition hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700"
                                                         aria-label="Close filters"
                                                 >
-                                                        <IoClose className="h-6 w-6" />
+                                                        <IoClose className="h-5 w-5" />
                                                 </button>
                                         </div>
 
-                                        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                                                {filters.map((filter) => (
-                                                        <div
-                                                                key={filter.key}
-                                                                className="flex flex-col gap-3 rounded-2xl border border-gray-200 p-4 shadow-sm"
+                                        <div className="flex-1 overflow-y-auto px-6 py-4">
+                                                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                                                        {filters.map((filter) => (
+                                                                <div
+                                                                        key={filter.key}
+                                                                        className="flex flex-col gap-4 rounded-2xl border border-gray-100 bg-white/70 p-4 shadow-sm"
+                                                                >
+                                                                        <div className="flex items-center justify-between gap-3">
+                                                                                <span className="text-sm font-semibold uppercase tracking-wide text-gray-600">
+                                                                                        {filter.headerTitle}
+                                                                                </span>
+                                                                                <button
+                                                                                        type="button"
+                                                                                        onClick={() => handleClearFilterGroup(filter.queryKey)}
+                                                                                        className="text-xs font-medium text-gray-400 transition hover:text-gray-600"
+                                                                                >
+                                                                                        Clear
+                                                                                </button>
+                                                                        </div>
+
+                                                                        <div className="flex max-h-52 flex-col gap-2 overflow-y-auto pr-1 text-sm text-gray-600">
+                                                                                {filter.items.map((item) => {
+                                                                                        const label = String(item.label);
+                                                                                        const checked = (filtersState[filter.queryKey] ?? []).includes(
+                                                                                                label,
+                                                                                        );
+
+                                                                                        return (
+                                                                                                <label
+                                                                                                        key={item.id}
+                                                                                                        className={`flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-2 text-sm transition-colors ${
+                                                                                                                checked
+                                                                                                                        ? "border-dark/60 bg-dark/5 text-gray-900"
+                                                                                                                        : "border-transparent text-gray-600 hover:border-gray-200 hover:bg-gray-50"
+                                                                                                        }`}
+                                                                                                >
+                                                                                                        <input
+                                                                                                                type="checkbox"
+                                                                                                                checked={checked}
+                                                                                                                onChange={() =>
+                                                                                                                        handleFilterSelection(
+                                                                                                                                filter.queryKey,
+                                                                                                                                label,
+                                                                                                                        )
+                                                                                                                }
+                                                                                                                className="h-4 w-4 rounded border-gray-300 text-dark focus:ring-dark/40"
+                                                                                                        />
+                                                                                                        <span className="truncate text-sm">{item.label}</span>
+                                                                                                </label>
+                                                                                        );
+                                                                                })}
+                                                                                {!filter.items.length && (
+                                                                                        <p className="text-xs text-gray-400">No options available</p>
+                                                                                )}
+                                                                        </div>
+                                                                </div>
+                                                        ))}
+                                                </div>
+                                        </div>
+
+                                        <div className="border-t border-gray-100 bg-gray-50 px-6 py-4">
+                                                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+                                                        <button
+                                                                type="button"
+                                                                onClick={() => setFiltersState(cloneFilterState(initialFilterState))}
+                                                                className="rounded-full border border-gray-200 bg-white px-6 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
                                                         >
-                                                                <div className="flex items-center justify-between gap-3">
-                                                                        <span className="text-sm font-semibold text-gray-700">
-                                                                                {filter.headerTitle}
-                                                                        </span>
-                                                                        <button
-                                                                                type="button"
-                                                                                onClick={() => handleClearFilterGroup(filter.queryKey)}
-                                                                                className="text-xs font-medium text-gray-500 transition hover:text-gray-700"
-                                                                        >
-                                                                                Clear
-                                                                        </button>
-                                                                </div>
-
-                                                                <div className="flex max-h-48 flex-col gap-2 overflow-y-auto pr-1 text-sm text-gray-600">
-                                                                        {filter.items.map((item) => {
-                                                                                const label = String(item.label);
-                                                                                const checked = (filtersState[filter.queryKey] ?? []).includes(
-                                                                                        label,
-                                                                                );
-
-                                                                                return (
-                                                                                        <label
-                                                                                                key={item.id}
-                                                                                                className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1 transition hover:bg-gray-100"
-                                                                                        >
-                                                                                                <input
-                                                                                                        type="checkbox"
-                                                                                                        checked={checked}
-                                                                                                        onChange={() =>
-                                                                                                                handleFilterSelection(
-                                                                                                                        filter.queryKey,
-                                                                                                                        label,
-                                                                                                                )
-                                                                                                        }
-                                                                                                        className="h-4 w-4 rounded border-gray-300 text-dark focus:ring-dark/40"
-                                                                                                />
-                                                                                                <span className="truncate text-sm text-gray-700">
-                                                                                                        {item.label}
-                                                                                                </span>
-                                                                                        </label>
-                                                                                );
-                                                                        })}
-                                                                        {!filter.items.length && (
-                                                                                <p className="text-xs text-gray-400">No options available</p>
-                                                                        )}
-                                                                </div>
-                                                        </div>
-                                                ))}
-                                        </div>
-
-                                        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
-                                                <button
-                                                        type="button"
-                                                        onClick={() => setFiltersState(cloneFilterState(initialFilterState))}
-                                                        className="rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
-                                                >
-                                                        Reset
-                                                </button>
-                                                <button
-                                                        type="button"
-                                                        onClick={handleApplyFilters}
-                                                        className="rounded-full bg-dark px-6 py-2 text-sm font-semibold text-white transition duration-200 hover:opacity-90"
-                                                >
-                                                        Apply filters
-                                                </button>
-                                                <button
-                                                        type="button"
-                                                        onClick={handleClearAll}
-                                                        className="rounded-full border border-gray-200 bg-white px-5 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
-                                                >
-                                                        Clear all
-                                                </button>
+                                                                Reset to defaults
+                                                        </button>
+                                                        <button
+                                                                type="button"
+                                                                onClick={handleClearAll}
+                                                                className="rounded-full border border-gray-200 bg-white px-6 py-2 text-sm font-medium text-gray-600 transition duration-200 hover:border-gray-300 hover:text-gray-800"
+                                                        >
+                                                                Clear all
+                                                        </button>
+                                                        <button
+                                                                type="button"
+                                                                onClick={handleApplyFilters}
+                                                                className="rounded-full bg-dark px-6 py-2 text-sm font-semibold text-white transition duration-200 hover:opacity-90"
+                                                        >
+                                                                Apply filters
+                                                        </button>
+                                                </div>
                                         </div>
                                 </div>
                         </div>


### PR DESCRIPTION
## Summary
- restyle the desktop filters modal with a centered elevated panel, updated typography, and higher z-index so it sits on top of the UI
- add scroll handling and refined checkbox styling to make long filter lists easier to browse
- prevent body scrolling while the modal is open for a focused experience and add backdrop click-to-close behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d58b704314833091a6c1c9408b124f