### PR TITLE
Remove loading placeholders during page transitions

### DIFF
--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import Topbar from "../../lib/components/toolBar/topbar";
 import JobItem from "../../lib/components/jobItem/jobItem";
 import { JobData, JobsPagePropsTypes, optionItems } from "@/lib/types/componentTypes";
@@ -194,11 +193,9 @@ const Jobs = async ({ searchParams }: JobsPagePropsTypes) => {
                                         </div>
 
                                         <div className="space-y-4">
-                                                <Suspense fallback={<div>Loading...</div>}>
-                                                        {jobResults.map((result: any) => (
-                                                                <JobItem data={result} key={result._id} />
-                                                        ))}
-                                                </Suspense>
+                                                {jobResults.map((result: any) => (
+                                                        <JobItem data={result} key={result._id} />
+                                                ))}
                                         </div>
 
                                         <div

--- a/app/post-job/page.tsx
+++ b/app/post-job/page.tsx
@@ -50,10 +50,8 @@ interface Inputs {
 	
 }
 const TextEditor = dynamic(() => import("@/lib/components/textEditor/TextEditor"), {
-	ssr: false,
-	loading: () => {
-		return <div className='font-semibold text-primary'>Loading...</div>;
-	},
+        ssr: false,
+        loading: () => null,
 });
 const PostJob = () => {
 	const [showCompanyDetails, setShowCompanyDetails] = useState<boolean>(false);

--- a/lib/components/dashboard/DashboardPage.tsx
+++ b/lib/components/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { Suspense, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import {redirect, useRouter} from "next/navigation";
 import toast from "react-hot-toast";
@@ -123,11 +123,9 @@ const DashboardPage = () => {
 
           <div className="space-y-4">
             {/*your job posts*/}
-              <Suspense fallback={<div>Loading...</div>}>
-                  {(showAllJobs ? jobs : jobs.slice(0, 5)).map((result: any) => (
-                    <MyJobPostItem data={result} key={result._id} />
-                  ))}
-              </Suspense>
+              {(showAllJobs ? jobs : jobs.slice(0, 5)).map((result: any) => (
+                <MyJobPostItem data={result} key={result._id} />
+              ))}
                 {jobs.length > 5 && !showAllJobs && (
                   <div className="flex justify-center mt-4">
                     <Button

--- a/lib/components/dashboard/MyFavoriteJobsPage.tsx
+++ b/lib/components/dashboard/MyFavoriteJobsPage.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { redirect } from "next/navigation";
 import Image from "next/image";
@@ -68,11 +68,9 @@ const MyFavoriteJobsPage = () => {
         </div>
 
         <div className="space-y-4">
-          <Suspense fallback={<div>Loading...</div>}>
-            {visibleJobs?.map((result: any) => (
-              <FavoriteJobPostItem data={result} key={result._id} />
-            ))}
-          </Suspense>
+          {visibleJobs?.map((result: any) => (
+            <FavoriteJobPostItem data={result} key={result._id} />
+          ))}
 
           {/* Show more button */}
           {!showAll && jobs?.length > 5 && (


### PR DESCRIPTION
## Summary
- remove Suspense placeholders from job and dashboard pages so navigation no longer flashes a loading screen
- drop the dynamic editor's loading fallback to eliminate the transition overlay when opening the post job form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d666967df483309519a0995522a35f