### PR TITLE
Add Stripe checkout confirmation flow without webhook

### DIFF
--- a/app/api/checkout/confirm/route.ts
+++ b/app/api/checkout/confirm/route.ts
@@ -1,0 +1,94 @@
+import mongoose from "mongoose";
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+
+import { PointsOrder } from "@/models/PointsOrder";
+import { User } from "@/models/User";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const { sessionId } = await req.json();
+
+  if (!sessionId || typeof sessionId !== "string") {
+    return NextResponse.json(
+      { error: "Missing Stripe session identifier" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+
+    if (!session) {
+      return NextResponse.json(
+        { error: "Stripe session not found" },
+        { status: 404 }
+      );
+    }
+
+    if (session.payment_status !== "paid") {
+      return NextResponse.json(
+        {
+          success: false,
+          status: session.payment_status,
+          message: "Payment has not been completed",
+        },
+        { status: 202 }
+      );
+    }
+
+    const orderId = session.metadata?.orderId;
+
+    if (!orderId) {
+      return NextResponse.json(
+        { error: "Missing order reference on Stripe session" },
+        { status: 400 }
+      );
+    }
+
+    await mongoose.connect(process.env.MONGODB_URI as string);
+
+    const order = await PointsOrder.findById(orderId);
+
+    if (!order) {
+      return NextResponse.json(
+        { error: "Order not found" },
+        { status: 404 }
+      );
+    }
+
+    if (!order.paid) {
+      order.paid = true;
+      await order.save();
+
+      const updatedUser = await User.findOneAndUpdate(
+        { email: order.userEmail },
+        { $inc: { jobPostPoints: order.points } },
+        { new: true }
+      );
+
+      if (!updatedUser) {
+        return NextResponse.json(
+          { error: "Unable to update user points" },
+          { status: 500 }
+        );
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "Payment confirmed",
+      pointsAwarded: order.points,
+    });
+  } catch (error) {
+    console.error("Failed to verify Stripe session", error);
+    return NextResponse.json(
+      { error: "Unable to verify payment status" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -79,7 +79,9 @@ export async function POST(req: Request) {
       line_items: stripeLineItems,
       mode: "payment",
       customer_email: userEmail,
-      success_url: resolveAbsoluteUrl("/success"),
+      success_url: resolveAbsoluteUrl(
+        "/success?session_id={CHECKOUT_SESSION_ID}"
+      ),
       cancel_url: resolveAbsoluteUrl("/error"),
       metadata: {
         orderId: orderDoc._id.toString(),
@@ -89,6 +91,7 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ url: stripeSession.url });
   } catch (error: unknown) {
+    console.error("Stripe checkout session creation failed", error);
     return NextResponse.json(
       { error, message: "Could not create checkout session" },
       { status: 500 }

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -1,26 +1,82 @@
 "use client";
-import React, { useEffect } from "react";
-import { useRouter } from "next/navigation";
-type Props = {};
 
-const Success = (props: Props) => {
-	const router = useRouter();
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 
-		useEffect(() => {
-		setTimeout(() => {
-			router.push("/");
-		}, 3500);
-	}, [router]);
+const SuccessPage = () => {
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get("session_id");
 
+  const [status, setStatus] = useState<"loading" | "success" | "error">(
+    "loading"
+  );
+  const [message, setMessage] = useState("Confirming your payment…");
 
+  useEffect(() => {
+    if (!sessionId) {
+      setStatus("error");
+      setMessage("We could not find your payment session.");
+      return;
+    }
 
+    const verifyPayment = async () => {
+      try {
+        const response = await fetch("/api/checkout/confirm", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionId }),
+        });
 
-	return (
-		<div className='flex flex-col items-center justify-center h-[85%] bg-[#009c77]'>
-			<h1 className='text-4xl font-bold text-white'>Success!</h1>
-			<p className='text-lg text-white'>Your payment has been processed.</p>
-		</div>
-	);
+        const payload = await response.json();
+
+        if (!response.ok || payload?.success === false) {
+          throw new Error(payload?.message || payload?.error || "");
+        }
+
+        setStatus("success");
+        setMessage(
+          payload?.message || "Your payment was confirmed successfully."
+        );
+      } catch (error) {
+        console.error("Stripe confirmation failed", error);
+        setStatus("error");
+        setMessage(
+          error instanceof Error && error.message
+            ? error.message
+            : "We were unable to confirm your payment."
+        );
+      }
+    };
+
+    verifyPayment();
+  }, [sessionId]);
+
+  return (
+    <section className="flex min-h-[60vh] items-center justify-center px-4 py-16">
+      <div className="max-w-xl rounded-2xl border border-slate-200 bg-white p-8 text-center shadow-lg">
+        <h1 className="text-3xl font-semibold text-slate-900">
+          {status === "success" ? "Payment successful" : "Payment status"}
+        </h1>
+        <p className="mt-4 text-base text-slate-600">{message}</p>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Link
+            href="/packages"
+            className="inline-flex items-center justify-center rounded-full bg-[#006c53] px-6 py-3 text-sm font-semibold text-white transition hover:bg-[#009c77]"
+          >
+            Browse packages
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-full border border-slate-200 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300"
+          >
+            Back to home
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
 };
 
-export default Success;
+export default SuccessPage;

--- a/models/PointsOrder.ts
+++ b/models/PointsOrder.ts
@@ -1,24 +1,27 @@
 import { Schema, model, models } from "mongoose";
 
 export type PointsOrderTypes = {
-    _id?: FormDataEntryValue;
-    userEmail: string;
-    title: string;
-    price: number;
-    points: number;
-    paymentType: string;
-    paid: boolean;
-    createdAt?: Date;
-  };
+  _id?: FormDataEntryValue;
+  userEmail: string;
+  title: string;
+  price: number;
+  points: number;
+  paymentType: string;
+  paid: boolean;
+  createdAt?: Date;
+};
 
-const PointsOrderSchema = new Schema({
-    userEmail: {type: String, required: true},
-    title: {type: String, required: true},
-	price: {type: Number, required: true},
-	points: {type: Number, required: true},
-    paymentType: {type: String},
-    paid: {type: Boolean, default: false},
-}, {timestamps: true});
+const PointsOrderSchema = new Schema(
+  {
+    userEmail: { type: String, required: true },
+    title: { type: String, required: true },
+    price: { type: Number, required: true },
+    points: { type: Number, required: true },
+    paymentType: { type: String },
+    paid: { type: Boolean, default: false },
+  },
+  { timestamps: true }
+);
 
-
-export const PointsOrder = models?.PointsOrder || model('PointsOrder', PointsOrderSchema);
+export const PointsOrder =
+  models?.PointsOrder || model("PointsOrder", PointsOrderSchema);


### PR DESCRIPTION
## Summary
- attach the checkout session identifier to the success redirect and improve logging when session creation fails
- add an API endpoint that verifies Stripe checkout sessions and finalises the corresponding order without requiring webhooks
- introduce a success page that calls the verification endpoint and tidies the PointsOrder schema definition

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d78fcbdba083309032e87c6c9a972d